### PR TITLE
Reframe results from "costs you" to "money back"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Thumbs.db
 scratch/
 coverage/
 .monocart-reporter/
+screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ npm run test:e2e:headed  # E2E with browser visible
 npm run test             # All tests (unit + e2e)
 npm run test:coverage    # All tests (Chromium) + V8 coverage report
 npm run deploy           # Deploy to GitHub Pages via gh-pages
+LABEL=foo npm run screenshots  # Full-page screenshots of every app state → screenshots/foo/
 ```
 
 Run a single unit test file:

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Charitable Tax Credit Calculator — Canada</title>
-  <meta name="description" content="Find out what your charitable donation actually costs you — the only calculator that checks whether you can really use the tax credit.">
+  <meta name="description" content="Find out what you get back from your charitable donation — the only calculator that checks whether you can really use the tax credit.">
 
   <!-- Open Graph (social sharing previews) -->
   <meta property="og:title" content="Charitable Tax Credit Calculator — Canada">
-  <meta property="og:description" content="Find out what your charitable donation actually costs you — the only calculator that checks whether you can really use the tax credit.">
+  <meta property="og:description" content="Find out what you get back from your charitable donation — the only calculator that checks whether you can really use the tax credit.">
   <meta property="og:image" content="https://danielabar.github.io/charitable-tax-credit-calculator-canada/icons/og-image.png">
   <meta property="og:url" content="https://danielabar.github.io/charitable-tax-credit-calculator-canada/">
   <meta property="og:type" content="website">

--- a/js/ui/results.js
+++ b/js/ui/results.js
@@ -12,7 +12,7 @@ import { UsabilityState } from "../check-credit-usability.js";
  * Build the big-number headline data based on usability state.
  */
 function buildHeadline(results) {
-  const { input, credit, usability } = results;
+  const { input, tax, credit, usability } = results;
   const donation = formatCurrency(input.donationAmount);
   const savings = formatCurrency(usability.actualSavings);
   const outOfPocket = formatCurrency(usability.outOfPocketCost);
@@ -24,24 +24,28 @@ function buildHeadline(results) {
         cardClass: "",
         colorClass: "positive",
         headlineLabel: `Your ${donation} donation to charity`,
-        headlineNumber: `Actually costs you ${outOfPocket}`,
-        headlineContext: `The tax credit saves you ${savings}, reducing your out-of-pocket cost by ${savingsPercent}.`,
+        headlineNumber: `You get ${savings} back`,
+        headlineContext: `Donate ${donation} and ${savings} goes right back in your pocket — a ${savingsPercent} return.`,
       };
-    case UsabilityState.PARTLY_WASTED:
+    case UsabilityState.PARTLY_WASTED: {
+      const total = formatCurrency(credit.totalCredit);
+      const taxOwed = formatCurrency(tax.totalTax);
+      const wasted = formatCurrency(usability.creditWasted);
       return {
         cardClass: "",
         colorClass: "positive",
         headlineLabel: `Your ${donation} donation to charity`,
-        headlineNumber: `Will save you ${savings} on taxes`,
-        headlineContext: `Your credit is ${formatCurrency(credit.totalCredit)}, but you can only use ${savings} of it. The remaining ${formatCurrency(usability.creditWasted)} can't be refunded.`,
+        headlineNumber: `You get ${savings} back`,
+        headlineContext: `Your credit would be ${total}, but you only owe ${taxOwed} in tax — so that's all that comes back to you. The remaining ${wasted} is lost.`,
       };
+    }
     case UsabilityState.ENTIRELY_WASTED:
       return {
         cardClass: "big-number-card--warning",
         colorClass: "warning",
         headlineLabel: `Your ${donation} donation to charity`,
-        headlineNumber: "Won't reduce your taxes this year",
-        headlineContext: "Based on your income, you don't owe enough tax to benefit from the credit. But you have options.",
+        headlineNumber: "You get $0 back this year",
+        headlineContext: "You don't owe any tax, so the credit has nothing to reduce. But you have options — keep reading.",
       };
   }
 }
@@ -73,8 +77,8 @@ async function buildSummaryGrid(results) {
       items = [
         { label: "Credit calculated", value: formatCurrency(credit.totalCredit), className: "teal" },
         { label: "Your estimated tax", value: formatCurrency(tax.totalTax), className: "muted" },
-        { label: "Credit you can use", value: formatCurrency(usability.creditUsable), className: "teal" },
-        { label: "Credit wasted", value: formatCurrency(usability.creditWasted), className: "red", highlight: true },
+        { label: "You get back", value: formatCurrency(usability.creditUsable), className: "teal" },
+        { label: "Lost", value: formatCurrency(usability.creditWasted), className: "red", highlight: true },
       ];
       break;
     case UsabilityState.ENTIRELY_WASTED:
@@ -82,8 +86,8 @@ async function buildSummaryGrid(results) {
       items = [
         { label: "Credit calculated", value: formatCurrency(credit.totalCredit), className: "muted" },
         { label: "Your estimated tax", value: formatCurrency(tax.totalTax), className: "muted" },
-        { label: "Credit you can use", value: "$0", className: "muted" },
-        { label: "Credit wasted", value: formatCurrency(credit.totalCredit), className: "red", highlight: true },
+        { label: "You get back", value: "$0", className: "muted" },
+        { label: "Lost", value: formatCurrency(credit.totalCredit), className: "red", highlight: true },
       ];
       break;
   }
@@ -119,11 +123,11 @@ async function buildBarChart(results) {
       const creditPercent = 100 - costPercent;
       const segments = [
         fillTemplate(segmentTemplate, { segmentClass: "cost", width: String(costPercent), segmentLabel: `${formatCurrency(usability.outOfPocketCost)} your cost` }),
-        fillTemplate(segmentTemplate, { segmentClass: "usable", width: String(creditPercent), segmentLabel: `${formatCurrency(credit.totalCredit)} credit` }),
+        fillTemplate(segmentTemplate, { segmentClass: "usable", width: String(creditPercent), segmentLabel: `${formatCurrency(credit.totalCredit)} back to you` }),
       ].join("\n");
       const legend = [
         fillTemplate(legendTemplate, { legendClass: "cost", legendLabel: "Your actual cost" }),
-        fillTemplate(legendTemplate, { legendClass: "usable", legendLabel: "Tax credit (savings)" }),
+        fillTemplate(legendTemplate, { legendClass: "usable", legendLabel: "Back to you (tax credit)" }),
       ].join("\n");
       return fillTemplate(chartTemplate, { barLabel: `How your ${donation} donation breaks down`, segments, legend });
     }
@@ -131,12 +135,12 @@ async function buildBarChart(results) {
       const usablePercent = Math.round((usability.creditUsable / credit.totalCredit) * 100);
       const wastedPercent = 100 - usablePercent;
       const segments = [
-        fillTemplate(segmentTemplate, { segmentClass: "usable", width: String(usablePercent), segmentLabel: `${formatCurrency(usability.creditUsable)} usable` }),
-        fillTemplate(segmentTemplate, { segmentClass: "wasted", width: String(wastedPercent), segmentLabel: `${formatCurrency(usability.creditWasted)} wasted` }),
+        fillTemplate(segmentTemplate, { segmentClass: "usable", width: String(usablePercent), segmentLabel: `${formatCurrency(usability.creditUsable)} back to you` }),
+        fillTemplate(segmentTemplate, { segmentClass: "wasted", width: String(wastedPercent), segmentLabel: `${formatCurrency(usability.creditWasted)} lost` }),
       ].join("\n");
       const legend = [
-        fillTemplate(legendTemplate, { legendClass: "usable", legendLabel: "Credit you can use" }),
-        fillTemplate(legendTemplate, { legendClass: "wasted", legendLabel: "Credit that disappears" }),
+        fillTemplate(legendTemplate, { legendClass: "usable", legendLabel: "Back to you" }),
+        fillTemplate(legendTemplate, { legendClass: "wasted", legendLabel: "Lost (non-refundable)" }),
       ].join("\n");
       return fillTemplate(chartTemplate, { barLabel: `Your ${formatCurrency(credit.totalCredit)} credit vs. your ${formatCurrency(usability.estimatedTax)} tax`, segments, legend });
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Charitable Tax Credit Calculator — Canada",
   "short_name": "Tax Credit Calc",
-  "description": "Find out what your charitable donation actually costs you — the only calculator that checks whether you can really use the tax credit.",
+  "description": "Find out what you get back from your charitable donation — the only calculator that checks whether you can really use the tax credit.",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e:chromium": "npx playwright-bdd && npx playwright test tests/e2e/ --project=e2e-chromium",
     "test": "npx playwright test tests/unit/ && npx playwright-bdd && npx playwright test tests/e2e/",
     "test:coverage": "npx playwright-bdd --config playwright.coverage.config.js && npx playwright test --config playwright.coverage.config.js",
-    "deploy": "gh-pages -d ."
+    "deploy": "gh-pages -d .",
+    "screenshots": "npx playwright test --config scripts/playwright.screenshots.config.js"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^11.0.0",

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -1,0 +1,101 @@
+import { test } from "@playwright/test";
+import { mkdirSync } from "fs";
+import { join } from "path";
+
+const label = process.env.LABEL || "default";
+const outputDir = join(process.cwd(), "screenshots", label);
+
+mkdirSync(outputDir, { recursive: true });
+
+const scenarios = [
+  {
+    name: "00-blank-form",
+    // No inputs — just capture the landing page
+  },
+  {
+    name: "01-full-benefit-above-200",
+    province: "Ontario",
+    income: "80000",
+    donation: "500",
+  },
+  {
+    name: "02-full-benefit-near-200",
+    province: "Ontario",
+    income: "80000",
+    donation: "180",
+  },
+  {
+    name: "03-full-benefit-below-200",
+    province: "Ontario",
+    income: "80000",
+    donation: "100",
+  },
+  {
+    name: "04-partly-wasted-above-200",
+    province: "Ontario",
+    income: "13000",
+    donation: "500",
+  },
+  {
+    name: "05-partly-wasted-near-200",
+    province: "Ontario",
+    income: "13000",
+    donation: "180",
+  },
+  {
+    name: "06-partly-wasted-below-200",
+    province: "Ontario",
+    income: "13000",
+    donation: "100",
+  },
+  {
+    name: "07-entirely-wasted-above-200",
+    province: "Ontario",
+    income: "10000",
+    donation: "500",
+  },
+  {
+    name: "08-entirely-wasted-near-200",
+    province: "Ontario",
+    income: "10000",
+    donation: "180",
+  },
+  {
+    name: "09-entirely-wasted-below-200",
+    province: "Ontario",
+    income: "10000",
+    donation: "100",
+  },
+  {
+    name: "10-top-bracket-above-200",
+    province: "Ontario",
+    income: "300000",
+    donation: "500",
+  },
+  {
+    name: "11-top-bracket-below-200",
+    province: "Ontario",
+    income: "300000",
+    donation: "100",
+  },
+];
+
+for (const scenario of scenarios) {
+  test(scenario.name, async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("#calculator-form");
+
+    if (scenario.province) {
+      await page.selectOption("#province", { label: scenario.province });
+      await page.fill("#income", scenario.income);
+      await page.fill("#donation", scenario.donation);
+      await page.click(".btn-calculate");
+      await page.waitForSelector(".results-section");
+    }
+
+    await page.screenshot({
+      path: join(outputDir, `${scenario.name}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/scripts/playwright.screenshots.config.js
+++ b/scripts/playwright.screenshots.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "capture-screenshots.js",
+  use: {
+    browserName: "chromium",
+    baseURL: "http://localhost:3000",
+    viewport: { width: 1280, height: 800 },
+  },
+  webServer: {
+    command: "npx serve .. -l 3000",
+    port: 3000,
+    reuseExistingServer: true,
+  },
+});

--- a/tests/e2e/features/donor-experience.feature
+++ b/tests/e2e/features/donor-experience.feature
@@ -12,7 +12,8 @@ Feature: Donor experience
     And I enter "500" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Actually costs you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
     And the credit summary should show federal credit, provincial credit, and total credit
@@ -37,7 +38,8 @@ Feature: Donor experience
     And I enter "180" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Actually costs you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
     And the credit summary should show federal credit, provincial credit, and total credit
@@ -61,7 +63,8 @@ Feature: Donor experience
     And I enter "100" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Actually costs you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
     And the credit summary should show federal credit, provincial credit, and total credit
@@ -85,10 +88,11 @@ Feature: Donor experience
     And I enter "500" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Will save you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
     # Visual breakdown
     And the visual breakdown should show usable versus wasted credit
     # Narrative
@@ -109,10 +113,11 @@ Feature: Donor experience
     And I enter "180" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Will save you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
     # Visual breakdown
     And the visual breakdown should show usable versus wasted credit
     # Narrative
@@ -133,10 +138,11 @@ Feature: Donor experience
     And I enter "100" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Will save you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
     # Visual breakdown
     And the visual breakdown should show usable versus wasted credit
     # Narrative
@@ -157,10 +163,10 @@ Feature: Donor experience
     And I enter "500" as my donation
     And I click Calculate
     # Bottom line — warning tone
-    Then the bottom line should say "Won't reduce your taxes"
+    Then the bottom line should say "You get $0 back"
     And the bottom line should show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
     # No visual breakdown for entirely wasted
     And there should be no visual breakdown
     # Narrative
@@ -181,10 +187,10 @@ Feature: Donor experience
     And I enter "180" as my donation
     And I click Calculate
     # Bottom line — warning tone
-    Then the bottom line should say "Won't reduce your taxes"
+    Then the bottom line should say "You get $0 back"
     And the bottom line should show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
     # No visual breakdown
     And there should be no visual breakdown
     # Narrative
@@ -205,10 +211,10 @@ Feature: Donor experience
     And I enter "100" as my donation
     And I click Calculate
     # Bottom line — warning tone
-    Then the bottom line should say "Won't reduce your taxes"
+    Then the bottom line should say "You get $0 back"
     And the bottom line should show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
     # No visual breakdown
     And there should be no visual breakdown
     # Narrative
@@ -229,7 +235,8 @@ Feature: Donor experience
     And I enter "500" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Actually costs you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
     And the credit summary should show federal credit, provincial credit, and total credit
@@ -254,7 +261,8 @@ Feature: Donor experience
     And I enter "100" as my donation
     And I click Calculate
     # Bottom line
-    Then the bottom line should say "Actually costs you"
+    Then the bottom line should say "You get"
+    And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
     And the credit summary should show federal credit, provincial credit, and total credit

--- a/tests/e2e/steps/donor-experience.js
+++ b/tests/e2e/steps/donor-experience.js
@@ -41,7 +41,7 @@ Then(
 );
 
 Then(
-  "the credit summary should show credit calculated, estimated tax, credit usable, and credit wasted",
+  "the credit summary should show credit calculated, estimated tax, amount back, and amount lost",
   async ({ page }) => {
     const grid = page.locator(".summary-grid");
     await expect(grid).toBeVisible();
@@ -50,9 +50,9 @@ Then(
     await expect(items).toHaveCount(4);
     await expect(items.nth(0).locator(".label")).toContainText("Credit calculated");
     await expect(items.nth(1).locator(".label")).toContainText("estimated tax");
-    await expect(items.nth(2).locator(".label")).toContainText("Credit you can use");
-    await expect(items.nth(3).locator(".label")).toContainText("Credit wasted");
-    // Credit wasted should be highlighted
+    await expect(items.nth(2).locator(".label")).toContainText("You get back");
+    await expect(items.nth(3).locator(".label")).toContainText("Lost");
+    // Lost amount should be highlighted
     await expect(items.nth(3)).toHaveClass(/highlight-bad/);
   },
 );

--- a/views/calculator/template.html
+++ b/views/calculator/template.html
@@ -1,6 +1,6 @@
 <div class="page">
   <div class="hero">
-    <h1>Find out what your charitable donation actually costs you</h1>
+    <h1>Find out what you get back from your charitable donation</h1>
     <p>The only calculator that tells you whether you can really use the tax credit — and what to do if you can't.</p>
   </div>
 


### PR DESCRIPTION
Fixes #2

## Summary
- Shift all user-facing copy from cost framing ("Actually costs you $X") to money-back framing ("You get $X back") — same math, more motivating lead message
- Update headline, context line, summary grid labels, bar chart labels/legends, page title, and meta descriptions across all three usability states
- Add screenshot capture utility for visual baselines

## Test plan
- [x] E2E tests updated and passing for new copy
- [ ] Visual review of all scenarios via `LABEL=2-reframe npm run screenshots`
  - Fully usable: $80k income / $500 donation
  - Partly wasted: $13k income / $500 donation
  - Entirely wasted: $10k income / $500 donation

🤖 Generated with [Claude Code](https://claude.com/claude-code)