### PR TITLE
[#6] Add reverse lookup refund cards to Learn page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ npx playwright-bdd && npx playwright test tests/e2e/ -g "feature name"
 
 Unit tests use **three layers** designed to be stable across tax year changes:
 
-- **Logic tests** (6 files like `calculate-federal-tax.spec.js`): Load fixture configs from `config/tax-data/test/` with round-number rates. Use exact assertions. Never need updating when real rates change.
+- **Logic tests** (7 files like `calculate-federal-tax.spec.js`): Load fixture configs from `config/tax-data/test/` with round-number rates. Use exact assertions. Never need updating when real rates change.
 - **Config validation** (`tax-data-validation.spec.js`): Validates real config structure and spot-checks specific rates. This is the only unit test file that needs updating for a new tax year.
 - **Smoke tests** (`smoke-current-year.spec.js`): Runs full pipeline against real config with range-based assertions. Catches integration issues without being fragile.
 

--- a/config/learn.json
+++ b/config/learn.json
@@ -4,5 +4,6 @@
     "partialTaxpayer":  { "income": 13500, "donation": 200 },
     "fullTaxpayerLow":  { "income": 55000, "donation": 200 },
     "fullTaxpayerHigh": { "income": 55000, "donation": 500 }
-  }
+  },
+  "reverseLookupTargets": [25, 50, 100, 200, 500]
 }

--- a/css/learn.css
+++ b/css/learn.css
@@ -257,10 +257,150 @@
     transform: translateX(2px);
   }
 
+  /* Refund cards (reverse lookup) */
+  .refund-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .refund-card {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    padding: 20px var(--space-lg);
+    display: grid;
+    grid-template-columns: 100px 1fr 120px;
+    align-items: center;
+    gap: 20px;
+    transition: border-color 0.15s;
+  }
+
+  .refund-card:hover {
+    border-color: var(--color-primary);
+  }
+
+  .refund-card-target {
+    text-align: center;
+  }
+
+  .refund-card-target .target-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    margin-bottom: 4px;
+  }
+
+  .refund-card-target .target-amount {
+    font-size: 26px;
+    font-weight: 700;
+    color: var(--color-primary-dark);
+    letter-spacing: -0.5px;
+  }
+
+  .refund-card-bar {
+    position: relative;
+  }
+
+  .bar-track {
+    height: 28px;
+    background: var(--color-bg-alt);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    display: flex;
+  }
+
+  .bar-low {
+    height: 100%;
+    background: var(--color-primary-light);
+    border-right: 2px solid oklch(85% 0.04 192);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--color-primary-dark);
+    white-space: nowrap;
+    min-width: 40px;
+  }
+
+  .bar-high {
+    height: 100%;
+    background: var(--color-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+  }
+
+  .bar-refund-marker {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 6px;
+  }
+
+  .bar-refund-fill {
+    height: 4px;
+    background: var(--color-primary-dark);
+    border-radius: 2px;
+  }
+
+  .bar-refund-label {
+    font-size: 11px;
+    color: var(--color-primary-dark);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .refund-card-donate {
+    text-align: right;
+  }
+
+  .refund-card-donate .donate-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    margin-bottom: 4px;
+  }
+
+  .refund-card-donate .donate-amount {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+  }
+
+  /* Rate callout */
+  .rate-callout {
+    background: var(--color-primary-light);
+    border: 1px dashed oklch(80% 0.04 192);
+    border-radius: var(--radius-sm);
+    padding: 10px var(--space-md);
+    font-size: 13px;
+    color: var(--color-primary-dark);
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .rate-callout-icon {
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+
   /* Responsive */
   @media (max-width: 640px) {
     .learn-page h1 { font-size: 24px; }
     .scenario-cards { grid-template-columns: 1fr; }
     .try-calculator p { max-width: none; }
+    .refund-card { grid-template-columns: 80px 1fr 100px; gap: 12px; padding: var(--space-md); }
+    .refund-card-target .target-amount { font-size: 22px; }
+    .refund-card-donate .donate-amount { font-size: 18px; }
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,6 +127,10 @@ calculator.js (orchestrator)
     │     └── determines fully-usable / partly-wasted / entirely-wasted
     ├── calculateMinimumIncome() (if credit partly/entirely wasted)
     └── nudge calculation (if near $200 threshold)
+
+calculateDonationForRefund(refund, federal, province)
+    └── inverse of donation credit — donation needed for target refund
+        (used by Learn page reverse lookup cards, not by the main calculator)
     ↓
 CalculationResults object
     ↓

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,7 @@ Config files are fetched via `js/load-config.js`, which caches them after the fi
 | `creditOutcomeScenarios` | object | Defines the four taxpayer scenarios shown on the Learn page |
 | `creditOutcomeScenarios.<key>.income` | number | Representative income for this scenario |
 | `creditOutcomeScenarios.<key>.donation` | number | Representative donation amount for this scenario |
+| `reverseLookupTargets` | array of numbers | Refund target amounts for the reverse lookup cards |
 
 The four scenario keys are:
 - `nonTaxpayer` — income below both federal and provincial BPA (tax = $0)
@@ -50,6 +51,8 @@ The four scenario keys are:
 These values are editorial choices — they should be round, relatable numbers
 that clearly illustrate each category. The Learn page computes tax, credit,
 and "gets back" amounts dynamically from these inputs using the Ontario config.
+
+`reverseLookupTargets` defines the "get back" amounts shown in the reverse lookup section. Each target triggers a reverse calculation to determine the donation needed. Values should be round, relatable numbers in ascending order. The first target should be achievable with a donation under $200 (to illustrate the low-rate tier).
 
 ## Tax data file format
 

--- a/js/calculate-donation-for-refund.js
+++ b/js/calculate-donation-for-refund.js
@@ -1,0 +1,23 @@
+/**
+ * Given a desired refund amount, compute the donation needed.
+ * Inverse of the donation credit calculation (federal + provincial combined).
+ *
+ * @param {number} desiredRefund - The amount the donor wants back
+ * @param {object} federalConfig - Federal config (donationCredit rates)
+ * @param {object} provinceConfig - Provincial config (donationCredit rates)
+ * @returns {number} Donation amount needed (rounded up to nearest dollar)
+ */
+export function calculateDonationForRefund(desiredRefund, federalConfig, provinceConfig) {
+  const lowRate = federalConfig.donationCredit.lowRate + provinceConfig.donationCredit.lowRate;
+  const highRate = federalConfig.donationCredit.highRate + provinceConfig.donationCredit.highRate;
+  const threshold = federalConfig.donationCredit.lowRateThreshold;
+
+  const maxCreditFromLowTier = threshold * lowRate;
+
+  if (desiredRefund <= maxCreditFromLowTier) {
+    return Math.ceil(desiredRefund / lowRate);
+  }
+
+  const remaining = desiredRefund - maxCreditFromLowTier;
+  return Math.ceil(threshold + remaining / highRate);
+}

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -105,3 +105,14 @@ for (const scenario of scenarios) {
     });
   });
 }
+
+// --- Non-calculator pages ---
+
+test("13-learn-page", async ({ page }) => {
+  await page.goto("/learn");
+  await page.waitForSelector(".learn-page");
+  await page.screenshot({
+    path: join(outputDir, "13-learn-page.png"),
+    fullPage: true,
+  });
+});

--- a/templates/refund-card.html
+++ b/templates/refund-card.html
@@ -1,0 +1,24 @@
+<div class="refund-card">
+  <div class="refund-card-target">
+    <div class="target-label">Get back</div>
+    <div class="target-amount">{{target}}</div>
+  </div>
+  <div class="refund-card-bar">
+    <div class="bar-track">
+      <div class="bar-low" style="width: {{lowPct}}%;">
+        {{lowLabel}}
+      </div>
+      <div class="bar-high" style="width: {{highPct}}%;">
+        {{highLabel}}
+      </div>
+    </div>
+    <div class="bar-refund-marker">
+      <div class="bar-refund-fill" style="width: {{refundPct}}%;"></div>
+      <span class="bar-refund-label">{{refundLabel}}</span>
+    </div>
+  </div>
+  <div class="refund-card-donate">
+    <div class="donate-label">Donate</div>
+    <div class="donate-amount">{{donation}}</div>
+  </div>
+</div>

--- a/tests/e2e/features/learn-page.feature
+++ b/tests/e2e/features/learn-page.feature
@@ -17,17 +17,20 @@ Feature: Learn page
     When I visit "/learn" directly
     Then I should see the Learn page content
 
-  Scenario: Learn page shows four scenario cards
+  Scenario: Learn page renders all content correctly
     Given I am on the Learn page
-    Then I should see 4 scenario cards
+    Then I should see the taxpayer categories section
+    And I should see 4 scenario cards
     And the non-taxpayer card should show $0 gets back
     And the partial taxpayer card should show a partial amount back
     And the full taxpayer cards should show the full credit back
-
-  Scenario: Learn page shows computed values not placeholders
-    Given I am on the Learn page
-    Then all scenario cards should show dollar amounts
+    And all scenario cards should show dollar amounts
     And no card should contain placeholder text
+    And I should see the reverse lookup section
+    And I should see 5 refund cards
+    And all refund cards should show dollar amounts
+    And no refund card should contain placeholder text
+    And I should see the rate callout explaining the threshold
 
   Scenario: CTA links to calculator
     Given I am on the Learn page

--- a/tests/e2e/steps/learn-page.js
+++ b/tests/e2e/steps/learn-page.js
@@ -12,6 +12,12 @@ Then("I should see the Learn page content", async ({ page }) => {
   await expect(heading).toHaveText("How the charitable tax credit works");
 });
 
+Then("I should see the taxpayer categories section", async ({ page }) => {
+  const heading = page.locator("#taxpayer-categories h2");
+  await expect(heading).toBeVisible();
+  await expect(heading).toContainText("What happens when you donate");
+});
+
 Then("I should see {int} scenario cards", async ({ page }, count) => {
   const cards = page.locator(".scenario-card");
   await expect(cards).toHaveCount(count);
@@ -67,4 +73,34 @@ Then("no card should contain placeholder text", async ({ page }) => {
 When("I click the calculator CTA", async ({ page }) => {
   await page.click('.try-calculator [data-route="/"]');
   await page.waitForSelector("#calculator-form");
+});
+
+Then("I should see the reverse lookup section", async ({ page }) => {
+  const heading = page.locator("#reverse-lookup h2");
+  await expect(heading).toBeVisible();
+  await expect(heading).toContainText("How much do I donate");
+});
+
+Then("I should see {int} refund cards", async ({ page }, count) => {
+  const cards = page.locator(".refund-card");
+  await expect(cards).toHaveCount(count);
+});
+
+Then("all refund cards should show dollar amounts", async ({ page }) => {
+  const amounts = page.locator(".refund-card .target-amount, .refund-card .donate-amount");
+  for (const el of await amounts.all()) {
+    await expect(el).toContainText("$");
+  }
+});
+
+Then("no refund card should contain placeholder text", async ({ page }) => {
+  const section = page.locator("#reverse-lookup");
+  const html = await section.innerHTML();
+  expect(html).not.toContain("{{");
+});
+
+Then("I should see the rate callout explaining the threshold", async ({ page }) => {
+  const callout = page.locator(".rate-callout");
+  await expect(callout).toBeVisible();
+  await expect(callout).toContainText("$200");
 });

--- a/tests/unit/calculate-donation-for-refund.spec.js
+++ b/tests/unit/calculate-donation-for-refund.spec.js
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { calculateDonationForRefund } from "../../js/calculate-donation-for-refund.js";
+
+const federalConfig = JSON.parse(
+  readFileSync(join(process.cwd(), "config/tax-data/test/federal.json"), "utf-8")
+);
+
+function loadProvince(code) {
+  return JSON.parse(
+    readFileSync(join(process.cwd(), `config/tax-data/test/provinces/${code}.json`), "utf-8")
+  );
+}
+
+const onConfig = loadProvince("ON");
+const abConfig = loadProvince("AB");
+
+// Test fixture rates (federal: 10%/20%, Ontario: 5%/10%):
+// Combined low rate = 15% (0.10 + 0.05)
+// Combined high rate = 30% (0.20 + 0.10)
+// Max credit from first $200 = $200 × 0.15 = $30
+
+test.describe("calculateDonationForRefund — Ontario fixture", () => {
+  test("$0 refund requires $0 donation", () => {
+    expect(calculateDonationForRefund(0, federalConfig, onConfig)).toBe(0);
+  });
+
+  test("$15 refund requires $100 donation (within low tier)", () => {
+    // $15 / 0.15 = $100
+    expect(calculateDonationForRefund(15, federalConfig, onConfig)).toBe(100);
+  });
+
+  test("$30 refund requires $200 donation (exactly at threshold)", () => {
+    // $30 / 0.15 = $200
+    expect(calculateDonationForRefund(30, federalConfig, onConfig)).toBe(200);
+  });
+
+  test("$45 refund requires $250 donation (above threshold)", () => {
+    // $30 from first $200 + $15 / 0.30 = $50 above
+    expect(calculateDonationForRefund(45, federalConfig, onConfig)).toBe(250);
+  });
+
+  test("$60 refund requires $300 donation (above threshold)", () => {
+    // $30 from first $200 + $30 / 0.30 = $100 above
+    expect(calculateDonationForRefund(60, federalConfig, onConfig)).toBe(300);
+  });
+
+  test("$1 refund requires $7 donation (rounds up)", () => {
+    // $1 / 0.15 = 6.67, ceil to $7
+    expect(calculateDonationForRefund(1, federalConfig, onConfig)).toBe(7);
+  });
+
+  test("$31 refund requires $204 donation (just over threshold, rounds up)", () => {
+    // $200 + $1 / 0.30 = $203.33, ceil to $204
+    expect(calculateDonationForRefund(31, federalConfig, onConfig)).toBe(204);
+  });
+});
+
+test.describe("calculateDonationForRefund — Alberta fixture", () => {
+  // Alberta test rates: federal 10%/20% + AB 10%/15%
+  // Combined low rate = 20% (0.10 + 0.10)
+  // Combined high rate = 35% (0.20 + 0.15)
+  // Max credit from first $200 = $200 × 0.20 = $40
+
+  test("$20 refund requires $100 donation (within low tier)", () => {
+    // $20 / 0.20 = $100
+    expect(calculateDonationForRefund(20, federalConfig, abConfig)).toBe(100);
+  });
+
+  test("$40 refund requires $200 donation (exactly at threshold)", () => {
+    // $40 / 0.20 = $200
+    expect(calculateDonationForRefund(40, federalConfig, abConfig)).toBe(200);
+  });
+
+  test("$75 refund requires $300 donation (above threshold)", () => {
+    // $40 from first $200 + $35 / 0.35 = $100 above
+    expect(calculateDonationForRefund(75, federalConfig, abConfig)).toBe(300);
+  });
+});

--- a/tests/unit/smoke-current-year.spec.js
+++ b/tests/unit/smoke-current-year.spec.js
@@ -9,6 +9,7 @@ import { join } from "path";
 import { calculateTotalTax } from "../../js/calculate-total-tax.js";
 import { calculateDonationCredit } from "../../js/calculate-donation-credit.js";
 import { checkCreditUsability } from "../../js/check-credit-usability.js";
+import { calculateDonationForRefund } from "../../js/calculate-donation-for-refund.js";
 
 const federalConfig = JSON.parse(
   readFileSync(join(process.cwd(), "config/tax-data/2026/federal.json"), "utf-8")
@@ -49,5 +50,26 @@ test.describe("smoke — current year (2026)", () => {
   test("zero donation returns zero credit", () => {
     const credit = calculateDonationCredit(0, 80000, federalConfig, onConfig);
     expect(credit.totalCredit).toBe(0);
+  });
+
+  test("reverse lookup: $100 refund requires donation between $300-$500 (ON)", () => {
+    const donation = calculateDonationForRefund(100, federalConfig, onConfig);
+    expect(donation).toBeGreaterThan(300);
+    expect(donation).toBeLessThan(500);
+  });
+
+  test("reverse lookup: $25 refund requires donation under $200 (ON)", () => {
+    const donation = calculateDonationForRefund(25, federalConfig, onConfig);
+    expect(donation).toBeLessThan(200);
+  });
+
+  test("reverse lookup: round-trip — credit from computed donation matches target", () => {
+    const target = 100;
+    const donation = calculateDonationForRefund(target, federalConfig, onConfig);
+    const credit = calculateDonationCredit(donation, 80000, federalConfig, onConfig);
+    // ceil rounding means actual credit should be >= target
+    expect(credit.totalCredit).toBeGreaterThanOrEqual(target);
+    // but not much more (at most ~$1 overshoot from rounding)
+    expect(credit.totalCredit).toBeLessThan(target + 2);
   });
 });

--- a/tests/unit/tax-data-validation.spec.js
+++ b/tests/unit/tax-data-validation.spec.js
@@ -194,4 +194,20 @@ test.describe("learn.json config", () => {
     expect(learnConfig.creditOutcomeScenarios.nonTaxpayer.income)
       .toBeLessThan(federal.incomeTax.basicPersonalAmount.maximum);
   });
+
+  test("has reverseLookupTargets as a non-empty array of positive numbers", () => {
+    expect(learnConfig.reverseLookupTargets).toBeDefined();
+    expect(Array.isArray(learnConfig.reverseLookupTargets)).toBe(true);
+    expect(learnConfig.reverseLookupTargets.length).toBeGreaterThan(0);
+    for (const target of learnConfig.reverseLookupTargets) {
+      expect(target).toBeGreaterThan(0);
+    }
+  });
+
+  test("reverseLookupTargets are in ascending order", () => {
+    const targets = learnConfig.reverseLookupTargets;
+    for (let i = 1; i < targets.length; i++) {
+      expect(targets[i]).toBeGreaterThan(targets[i - 1]);
+    }
+  });
 });

--- a/views/learn/script.js
+++ b/views/learn/script.js
@@ -2,13 +2,15 @@ import { loadConfig, loadFederalConfig, loadProvinceConfig } from "../../js/load
 import { calculateTotalTax } from "../../js/calculate-total-tax.js";
 import { calculateDonationCredit } from "../../js/calculate-donation-credit.js";
 import { checkCreditUsability } from "../../js/check-credit-usability.js";
-import { fillTemplate } from "../../js/ui/template-loader.js";
+import { calculateDonationForRefund } from "../../js/calculate-donation-for-refund.js";
+import { loadTemplate, fillTemplate } from "../../js/ui/template-loader.js";
 
 export async function init(contentEl, html) {
-  const [learnConfig, federal, province] = await Promise.all([
+  const [learnConfig, federal, province, cardTemplate] = await Promise.all([
     loadConfig("config/learn.json"),
     loadFederalConfig(),
     loadProvinceConfig("ON"),
+    loadTemplate("templates/refund-card.html"),
   ]);
 
   const scenarios = learnConfig.creditOutcomeScenarios;
@@ -26,6 +28,45 @@ export async function init(contentEl, html) {
     data[`${key}_getsBack`] = formatWhole(usability.creditUsable);
   }
 
+  // Reverse lookup cards
+  const lowRate = federal.donationCredit.lowRate + province.donationCredit.lowRate;
+  const highRate = federal.donationCredit.highRate + province.donationCredit.highRate;
+  const threshold = federal.donationCredit.lowRateThreshold;
+
+  const targets = learnConfig.reverseLookupTargets;
+  const cardFragments = targets.map((target) => {
+    const donation = calculateDonationForRefund(target, federal, province);
+    const lowPortion = Math.min(donation, threshold);
+    const highPortion = Math.max(0, donation - threshold);
+    const lowPct = Math.round((lowPortion / donation) * 100);
+    const highPct = 100 - lowPct;
+    const refundPct = Math.round((target / donation) * 100);
+
+    return fillTemplate(cardTemplate, {
+      target: formatWhole(target),
+      donation: formatWhole(donation),
+      lowPct,
+      lowLabel: `${formatWhole(lowPortion)} at ${formatPercent(lowRate)}`,
+      highPct,
+      highLabel: highPortion > 0
+        ? `${formatWhole(highPortion)} at ${formatPercent(highRate)}`
+        : '',
+      refundPct,
+      refundLabel: `${formatWhole(target)} back`,
+    });
+  });
+
+  // Insert rate callout between first and second card — threshold from config, never hardcoded
+  const formattedThreshold = formatWhole(threshold);
+  const rateCallout = `<div class="rate-callout">
+    <span class="rate-callout-icon">&#x26A0;</span>
+    The first ${formattedThreshold} of donations earns credit at ${formatPercent(lowRate)}.
+    Above ${formattedThreshold}, the rate jumps to ${formatPercent(highRate)} — more than double.
+  </div>`;
+  cardFragments.splice(1, 0, rateCallout);
+
+  data.refundCards = cardFragments.join("\n");
+
   contentEl.innerHTML = fillTemplate(html, data);
 }
 
@@ -33,4 +74,8 @@ export function destroy() {}
 
 function formatWhole(amount) {
   return "$" + Math.round(amount).toLocaleString("en-CA");
+}
+
+function formatPercent(rate) {
+  return Math.round(rate * 100) + '%';
 }

--- a/views/learn/template.html
+++ b/views/learn/template.html
@@ -181,6 +181,19 @@
     <p class="province-note">Based on Ontario 2026 federal + provincial rates. Your results will vary by province.</p>
   </section>
 
+  <section id="reverse-lookup" class="learn-section">
+    <h2>How much do I donate to get money back?</h2>
+    <p class="section-intro">If you owe enough tax to use the full credit,
+      here's how much you'd need to donate to get a specific amount back.</p>
+
+    <div class="refund-cards">
+      {{refundCards}}
+    </div>
+
+    <p class="province-note">Based on Ontario 2026 federal + provincial rates.
+      Your results will vary by province.</p>
+  </section>
+
   <div class="try-calculator">
     <p><strong>Want to see your specific situation?</strong> Enter your income and donation amount to get a personalized breakdown.</p>
     <a href="./" data-route="/" class="cta-link">Try the calculator</a>


### PR DESCRIPTION
## Summary

- Adds "How much do I donate to get money back?" section to the Learn page with 5 config-driven refund target cards ($25, $50, $100, $200, $500)
- Each card shows donation needed, a rate-tier bar (19% vs 40% split), and a refund marker showing what fraction comes back
- Uses sub-template pattern (`templates/refund-card.html`) so targets are config-only changes — no template edits needed

Closes #6

## Test plan

- [x] 10 unit tests for reverse calculation (fixture configs, ON + AB)
- [x] 2 config validation tests for `reverseLookupTargets`
- [x] 3 smoke tests with real config (range checks + round-trip verification)
- [x] 3 E2E scenarios (section visible, cards rendered, rate callout)
- [x] All 147 unit tests pass
- [x] All 33 E2E tests pass
- [x] Manual browser verification of card layout and bar visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)