### PR TITLE
[#7] Add reverse calculator mode — "How much should I donate?"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,11 @@ npx playwright-bdd && npx playwright test tests/e2e/ -g "feature name"
 
 **SPA Router** (`js/router.js`): Custom pushState router with three routes (`/` calculator, `/learn`, `/about`). Views live in `views/<name>/` with `template.html` + `script.js` (init/destroy lifecycle). Templates are lazy-loaded and cached by `js/ui/template-loader.js`. The router passes the content element and raw HTML to each view's `init(contentEl, html)` — the view is responsible for inserting its own content into the DOM. This lets views with async data (like `/learn`) fill templates before insertion, preventing flash of placeholder text. Base path auto-detected for GitHub Pages in `js/base-path.js`.
 
-**Calculation Pipeline** (`js/calculator.js`): Orchestrates the full computation — loads configs, calculates total tax (brackets + Ontario surtax), donation credit (tiered rates), credit usability (non-refundable credit limitations), minimum income needed, and nudge hints. Returns a single result object consumed by the UI.
+**Calculation Pipeline** (`js/calculator.js`): Orchestrates the full computation — loads configs, calculates total tax (brackets + Ontario surtax), donation credit (tiered rates), credit usability (non-refundable credit limitations), minimum income needed, and nudge hints. Returns a single result object consumed by the UI. The calculator has two modes: forward (`runCalculation` — "I donated $X, what do I get back?") and reverse (`runReverseCalculation` — "I want $Y back, how much should I donate?"). Both reuse the same pure calculation functions.
 
-**Tax Data** (`config/tax-data/2026/`): Federal and provincial rates/brackets in JSON. Rates are never hardcoded in JS — always loaded from config. `config/app-settings.json` holds narrative thresholds and nudge percentages.
+**Tax Data** (`config/tax-data/2026/`): Federal and provincial rates/brackets in JSON. Rates are never hardcoded in JS — always loaded from config. `config/app-settings.json` holds narrative thresholds, nudge percentages, and reverse slider range settings.
 
-**UI Layer** (`js/ui/`): Form handling, results rendering, narrative builder, and URL state sync (query params for shareable links).
+**UI Layer** (`js/ui/`): Form handling, results rendering, narrative builder (`narrative.js` for forward mode, `reverse-narrative.js` for reverse mode warning banners), and URL state sync (query params for shareable links). Forward-mode URLs use `?province=ON&income=60000&donation=500`. Reverse-mode URLs add `mode=reverse` and use `refund` instead of `donation`: `?mode=reverse&province=ON&income=60000&refund=100`.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ A free, open-source tool that honestly tells Canadians what they get back from c
 - Tiered federal + provincial donation credit rates (first $200 / over $200)
 - 33% top-bracket federal credit rate for high-income donors
 
+**Reverse calculator mode**
+- "How much should I donate to get $Y back?" — interactive slider to explore refund targets
+- Shows the donation needed, with a breakdown of low-rate vs high-rate portions
+- Warns when income is too low to use the full credit (partial or entirely wasted)
+
 **Honesty about limitations**
 - Shows when the non-refundable credit exceeds your tax payable (partially or fully wasted)
 - Calculates the minimum income needed to use the full credit
@@ -22,6 +27,7 @@ A free, open-source tool that honestly tells Canadians what they get back from c
 
 **Educational content**
 - Learn page showing how the same donation produces different results for different taxpayer types
+- Reverse lookup cards showing how much to donate for specific refund amounts
 
 **Plain-language results**
 - Narrative explanations in real dollar amounts

--- a/config/app-settings.json
+++ b/config/app-settings.json
@@ -2,5 +2,11 @@
   "narrative": {
     "thresholdProximityPercent": 0.75,
     "nudgeAboveThresholdPercent": 0.25
+  },
+  "reverseSlider": {
+    "min": 10,
+    "max": 500,
+    "defaultValue": 100,
+    "step": 1
   }
 }

--- a/css/index.css
+++ b/css/index.css
@@ -9,4 +9,5 @@
 @import "results.css";
 @import "narrative.css";
 @import "learn.css";
+@import "slider.css";
 @import "utilities.css";

--- a/css/results.css
+++ b/css/results.css
@@ -210,6 +210,71 @@
     color: var(--color-text);
   }
 
+  /* Tab card wrapper */
+  .tab-card {
+    margin-top: var(--space-lg);
+  }
+
+  /* Mode toggle (tabs) */
+  .mode-toggle {
+    display: flex;
+    position: relative;
+  }
+
+  .mode-toggle button {
+    flex: 1;
+    padding: 13px var(--space-md);
+    font-size: 14px;
+    font-weight: 600;
+    font-family: var(--font-stack);
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-alt);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .mode-toggle button:first-child {
+    border-radius: var(--radius) 0 0 0;
+    border-right: none;
+  }
+
+  .mode-toggle button:last-child {
+    border-radius: 0 var(--radius) 0 0;
+    border-left: none;
+  }
+
+  /* Divider line between tabs */
+  .mode-toggle::after {
+    content: "";
+    position: absolute;
+    top: 1px;
+    bottom: 1px;
+    left: 50%;
+    width: 1px;
+    background: var(--color-border);
+    z-index: 3;
+    pointer-events: none;
+  }
+
+  .mode-toggle button:hover:not(.active) {
+    color: var(--color-text);
+  }
+
+  .mode-toggle button.active {
+    background: var(--color-bg);
+    color: var(--color-primary-dark);
+    border-bottom-color: transparent;
+    z-index: 2;
+  }
+
+  /* Input card merges with tabs above */
+  .tab-panel-card > .input-card:first-child {
+    margin-top: 0;
+    border-top: none;
+    border-radius: 0 0 var(--radius) var(--radius);
+  }
+
   @media (max-width: 640px) {
     .big-number-card .headline-number {
       font-size: 36px;
@@ -221,6 +286,11 @@
 
     .summary-grid.three-col {
       grid-template-columns: 1fr;
+    }
+
+    .mode-toggle button {
+      font-size: 13px;
+      padding: 10px var(--space-sm);
     }
   }
 }

--- a/css/slider.css
+++ b/css/slider.css
@@ -1,0 +1,254 @@
+@layer components {
+  /* Slider widget (reverse calculator mode) */
+  .slider-widget {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    padding: var(--space-xl);
+    margin: var(--space-lg) 0 0;
+    background: #fff;
+  }
+
+  .slider-question {
+    font-size: 16px;
+    font-weight: 600;
+    text-align: center;
+    color: var(--color-text);
+    margin-bottom: var(--space-lg);
+  }
+
+  .slider-target-amount {
+    color: var(--color-primary-dark);
+    font-size: 36px;
+    display: block;
+    margin-top: 4px;
+    letter-spacing: -1px;
+    font-weight: 700;
+  }
+
+  /* Range input */
+  .slider-container {
+    position: relative;
+    padding: 0 8px;
+    margin-bottom: var(--space-xl);
+  }
+
+  .slider-input {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    background: linear-gradient(to right, var(--color-primary-light) 0%, var(--color-primary) 100%);
+    outline: none;
+    cursor: pointer;
+  }
+
+  .slider-input::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--color-primary-dark);
+    border: 3px solid #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    cursor: grab;
+  }
+
+  .slider-input::-webkit-slider-thumb:active {
+    cursor: grabbing;
+  }
+
+  .slider-input::-moz-range-thumb {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--color-primary-dark);
+    border: 3px solid #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    cursor: grab;
+  }
+
+  .slider-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--space-sm);
+    font-size: 12px;
+    color: var(--color-text-secondary);
+    font-weight: 500;
+  }
+
+  /* Donate → Refund result display */
+  .slider-result {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 40px;
+    margin-bottom: 28px;
+  }
+
+  .slider-result-box {
+    text-align: center;
+  }
+
+  .slider-result-box .srb-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    margin-bottom: 4px;
+  }
+
+  .slider-result-box .srb-amount {
+    font-size: 32px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+  }
+
+  .slider-result-box .srb-amount.donate-val {
+    color: var(--color-text);
+  }
+
+  .slider-result-box .srb-amount.refund-val {
+    color: var(--color-primary-dark);
+  }
+
+  .slider-result-arrow {
+    font-size: 24px;
+    color: var(--color-text-secondary);
+    margin-top: 16px;
+  }
+
+  /* Dimmed state (entirely wasted) */
+  .slider-result.dimmed,
+  .breakdown.dimmed {
+    opacity: 0.35;
+  }
+
+  /* Donation breakdown bar */
+  .breakdown {
+    background: var(--color-bg-alt);
+    border-radius: var(--radius-sm);
+    padding: 20px;
+  }
+
+  .breakdown-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    margin-bottom: 12px;
+  }
+
+  .breakdown-bar {
+    display: flex;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    margin-bottom: 12px;
+  }
+
+  .breakdown-bar .seg-low {
+    background: #b5d8d8;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-primary-dark);
+    border-right: 2px solid #fff;
+    transition: width 0.3s ease;
+  }
+
+  .breakdown-bar .seg-high {
+    background: var(--color-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: #fff;
+    transition: width 0.3s ease;
+  }
+
+  .breakdown-legend {
+    display: flex;
+    gap: 24px;
+    font-size: 13px;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .legend-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+  }
+
+  .legend-swatch.swatch-low {
+    background: #b5d8d8;
+  }
+
+  .legend-swatch.swatch-high {
+    background: var(--color-primary);
+  }
+
+  /* Warning banners */
+  .slider-warning {
+    background: var(--color-wasted-bg);
+    border-left: 3px solid var(--color-wasted);
+    border-radius: var(--radius-sm);
+    padding: var(--space-md) var(--space-lg);
+    margin-bottom: 28px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--color-text);
+  }
+
+  .slider-warning strong {
+    font-weight: 700;
+    color: var(--color-wasted);
+  }
+
+  .slider-partial-warning {
+    background: var(--color-accent-light);
+    border-left: 3px solid var(--color-accent);
+    border-radius: var(--radius-sm);
+    padding: var(--space-md) var(--space-lg);
+    margin-bottom: 28px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--color-text);
+  }
+
+  .slider-partial-warning strong {
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+
+  .slider-warning .learn-link,
+  .slider-partial-warning .learn-link {
+    display: flex;
+    width: fit-content;
+  }
+
+  @media (max-width: 640px) {
+    .slider-widget {
+      padding: var(--space-lg) var(--space-md);
+    }
+
+    .slider-result {
+      gap: 20px;
+    }
+
+    .slider-result-box .srb-amount {
+      font-size: 26px;
+    }
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,8 @@ The narrative (`js/ui/narrative.js`) conditionally includes sections based on th
 | Learn link (non-refundable) | No | Yes | Yes |
 | Learn link (closing) | No | No | Yes |
 
+**Reverse mode** has its own narrative module (`js/ui/reverse-narrative.js`) that builds warning banners for the slider widget. It handles three states: fully usable (no banner), partly wasted (amber banner), and entirely wasted (red banner). Each banner includes a Learn page link.
+
 ### How to add a new component (template + rendering)
 
 1. Create `templates/<name>.html` with `{{placeholder}}` markers
@@ -130,7 +132,7 @@ calculator.js (orchestrator)
 
 calculateDonationForRefund(refund, federal, province)
     └── inverse of donation credit — donation needed for target refund
-        (used by Learn page reverse lookup cards, not by the main calculator)
+        (used by Learn page reverse lookup cards and reverse calculator mode)
     ↓
 CalculationResults object
     ↓
@@ -138,6 +140,29 @@ UI rendering (results.js + narrative.js)
     ↓
 DOM
 ```
+
+### Reverse calculation pipeline
+
+The calculator has a second mode — "How much should I donate to get $Y back?" — driven by `runReverseCalculation()` in `calculator.js`:
+
+```
+User input (province, income, desiredRefund)
+    ↓
+calculator.js → runReverseCalculation()
+    ├── calculateDonationForRefund(refund, federal, province) → donationNeeded
+    ├── calculateTotalTax(income, federal, province) → tax
+    ├── calculateDonationCredit(donationNeeded, income, federal, province) → credit
+    ├── checkCreditUsability(credit, tax, donationNeeded) → usability
+    └── calculateMinimumIncome() (if not fully usable)
+    ↓
+ ReverseCalculationResults object
+    ↓
+UI rendering (reverse-narrative.js → warning banners in slider widget)
+    ↓
+DOM
+```
+
+The reverse pipeline reuses the same pure calculation functions as the forward pipeline, just composed in a different order. Warning banners for the slider are built by `js/ui/reverse-narrative.js` (separate from `narrative.js` which handles forward mode).
 
 ### The results object
 
@@ -291,6 +316,7 @@ Layers are processed in order — later layers override earlier ones regardless 
 | `results.css` | `components` | Results section (summary grid, bar chart, big number) |
 | `narrative.css` | `components` | Narrative sections and callout boxes |
 | `learn.css` | `components` | Learn page (scenario cards, result flow, CTA) and narrative learn links |
+| `slider.css` | `components` | Reverse mode slider widget (range input, result boxes, breakdown bar) |
 | `utilities.css` | `utilities` | Utility/helper classes |
 | `index.css` | — | Imports all CSS files in order |
 
@@ -325,8 +351,10 @@ Spacing: `--space-xs` (4px) through `--space-2xl` (48px)
 
 ### "I want to add a new narrative section"
 
-1. Write the section builder function in `js/ui/narrative.js` (following the existing pattern)
-2. Add conditional logic in `buildAllSections()` to include it
+Forward mode: edit `js/ui/narrative.js`. Reverse mode: edit `js/ui/reverse-narrative.js`. Each file handles one calculator mode.
+
+1. Write the section builder function in the appropriate narrative module (following the existing pattern)
+2. Add conditional logic in `buildAllSections()` (forward) or `buildReverseWarning()` (reverse) to include it
 3. If it needs a new template, create it in `templates/` and use `loadTemplate()`/`fillTemplate()`
 4. Add e2e test steps to verify it appears/doesn't appear in the right scenarios
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,12 @@ Config files are fetched via `js/load-config.js`, which caches them after the fi
   "narrative": {
     "thresholdProximityPercent": 0.75,
     "nudgeAboveThresholdPercent": 0.25
+  },
+  "reverseSlider": {
+    "min": 10,
+    "max": 500,
+    "defaultValue": 100,
+    "step": 1
   }
 }
 ```
@@ -30,6 +36,10 @@ Config files are fetched via `js/load-config.js`, which caches them after the fi
 |---|---|---|---|
 | `narrative.thresholdProximityPercent` | number (0–1) | `0.75` | How close a donation must be to the $200 threshold to trigger the nudge hint. At `0.75`, donations of $150+ show the nudge. |
 | `narrative.nudgeAboveThresholdPercent` | number (0–1) | `0.25` | How far above the threshold the hypothetical nudge amount is. At `0.25`, the nudge suggests $250 (200 * 1.25). |
+| `reverseSlider.min` | number | `10` | Minimum refund amount on the reverse mode slider. |
+| `reverseSlider.max` | number | `500` | Maximum refund amount on the reverse mode slider. |
+| `reverseSlider.defaultValue` | number | `100` | Default slider position when reverse mode is first opened. |
+| `reverseSlider.step` | number | `1` | Step increment for the slider (1 = dollar-by-dollar). |
 
 ## Learn config reference
 

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -1,5 +1,7 @@
 /**
  * Full calculation pipeline — orchestrates all modules.
+ * Provides both forward ("I donated X, what do I get back?") and
+ * reverse ("I want Y back, how much do I donate?") pipelines.
  */
 
 import { loadFederalConfig, loadProvinceConfig, loadAppSettings } from "./load-config.js";
@@ -8,6 +10,7 @@ import { calculateDonationCredit } from "./calculate-donation-credit.js";
 import { checkCreditUsability, UsabilityState } from "./check-credit-usability.js";
 import { calculateMinimumIncome } from "./calculate-minimum-income.js";
 import { calculateNudge } from "./calculate-nudge.js";
+import { calculateDonationForRefund } from "./calculate-donation-for-refund.js";
 
 /**
  * @typedef {object} CalculationResults
@@ -97,5 +100,77 @@ export async function runCalculation(provinceCode, income, donationAmount) {
     nudge,
     donationRates,
     appSettings,
+  };
+}
+
+/**
+ * @typedef {object} ReverseCalculationResults
+ * @property {'reverse'} mode
+ * @property {object} input
+ * @property {string} input.provinceCode
+ * @property {string} input.provinceName
+ * @property {number} input.income
+ * @property {number} input.desiredRefund
+ * @property {number} donationNeeded - The central answer: how much to donate
+ * @property {object} tax
+ * @property {object} credit
+ * @property {object} usability
+ * @property {number|null} minimumIncome
+ * @property {object} donationRates
+ */
+
+/**
+ * Run the reverse calculation pipeline.
+ * Given a desired refund, compute the donation needed and check usability.
+ * @param {string} provinceCode
+ * @param {number} income
+ * @param {number} desiredRefund
+ * @returns {Promise<ReverseCalculationResults>}
+ */
+export async function runReverseCalculation(provinceCode, income, desiredRefund) {
+  const [federal, province] = await Promise.all([
+    loadFederalConfig(),
+    loadProvinceConfig(provinceCode),
+  ]);
+
+  // 1. How much to donate for the desired refund (assumes full taxpayer)
+  const donationNeeded = calculateDonationForRefund(desiredRefund, federal, province);
+
+  // 2. What tax does this person owe?
+  const tax = calculateTotalTax(income, federal, province);
+
+  // 3. What credit does this donation actually generate?
+  const credit = calculateDonationCredit(donationNeeded, income, federal, province);
+
+  // 4. Can they use the full credit?
+  const usability = checkCreditUsability(credit.totalCredit, tax.totalTax, donationNeeded);
+
+  // 5. If not fully usable, what income would they need?
+  let minimumIncome = null;
+  if (usability.state !== UsabilityState.FULLY_USABLE) {
+    minimumIncome = calculateMinimumIncome(credit.totalCredit, federal, province);
+  }
+
+  const donationRates = {
+    threshold: federal.donationCredit.lowRateThreshold,
+    federal: {
+      lowRate: federal.donationCredit.lowRate,
+      highRate: federal.donationCredit.highRate,
+    },
+    provincial: {
+      lowRate: province.donationCredit.lowRate,
+      highRate: province.donationCredit.highRate,
+    },
+  };
+
+  return {
+    mode: 'reverse',
+    input: { provinceCode, provinceName: province.name, income, desiredRefund },
+    donationNeeded,
+    tax,
+    credit,
+    usability,
+    minimumIncome,
+    donationRates,
   };
 }

--- a/js/ui/form.js
+++ b/js/ui/form.js
@@ -8,7 +8,7 @@
  * Strips $, commas, and whitespace.
  * Returns NaN for empty or invalid input.
  */
-function parseCurrency(value) {
+export function parseCurrency(value) {
   const cleaned = value.replace(/[$,\s]/g, "");
   if (cleaned === "") return NaN;
   return Number(cleaned);

--- a/js/ui/narrative.js
+++ b/js/ui/narrative.js
@@ -1,5 +1,9 @@
 /**
- * Build the "Your story in numbers" narrative HTML.
+ * Build the "Your story in numbers" narrative for FORWARD calculator mode.
+ *
+ * This module handles the forward question: "I donated $X — what do I get back?"
+ * For the reverse question ("I want $Y back — how much do I donate?"), see reverse-narrative.js.
+ *
  * Sections are conditionally included based on usability state.
  * Uses HTML sub-templates from templates/ directory.
  */

--- a/js/ui/reverse-narrative.js
+++ b/js/ui/reverse-narrative.js
@@ -1,0 +1,49 @@
+/**
+ * Build warning banner HTML for REVERSE calculator mode.
+ *
+ * This module handles the reverse question: "I want $Y back — how much do I donate?"
+ * For the forward question ("I donated $X — what do I get back?"), see narrative.js.
+ *
+ * Separated from narrative.js for clarity — each file handles one calculator mode
+ * with no conditional branching on mode scattered throughout.
+ *
+ * Returns HTML for contextual warning banners shown in the slider widget:
+ * - Fully usable: empty string (no warning needed)
+ * - Partly wasted: amber banner explaining capped refund
+ * - Entirely wasted: red banner explaining non-refundable credit
+ */
+
+import { formatCurrency } from "../format.js";
+
+/**
+ * Build the warning banner HTML for the reverse slider, or empty string if fully usable.
+ * @param {import('../calculator.js').ReverseCalculationResults} results
+ * @returns {string} HTML string (warning banner or empty)
+ */
+export function buildReverseWarning(results) {
+  const { usability, input, minimumIncome } = results;
+
+  if (usability.state === "fully-usable") {
+    return "";
+  }
+
+  if (usability.state === "entirely-wasted") {
+    return `<div class="slider-warning">
+      <strong>Not possible at your income.</strong>
+      At ${formatCurrency(input.income)}, you don't owe any income tax.
+      The charitable tax credit is non-refundable — it can only reduce tax you owe.
+      You'd need to earn approximately <strong>${formatCurrency(minimumIncome)}</strong>
+      to get ${formatCurrency(input.desiredRefund)} back.
+      <a href="learn" data-route="/learn" class="learn-link">Learn why income determines your refund <span class="arrow">&rarr;</span></a>
+    </div>`;
+  }
+
+  // partly-wasted
+  return `<div class="slider-partial-warning">
+    <strong>You can only get ${formatCurrency(usability.creditUsable)} back at your income.</strong>
+    You owe ${formatCurrency(usability.estimatedTax)} in tax — that's the most the credit can reduce.
+    To get the full ${formatCurrency(input.desiredRefund)}, you'd need to earn approximately
+    <strong>${formatCurrency(minimumIncome)}</strong>.
+    <a href="learn" data-route="/learn" class="learn-link">Learn why income determines your refund <span class="arrow">&rarr;</span></a>
+  </div>`;
+}

--- a/js/ui/url-state.js
+++ b/js/ui/url-state.js
@@ -5,31 +5,82 @@
 
 /**
  * Update the URL with calculator inputs (without page reload).
+ * @param {string} province
+ * @param {number} income
+ * @param {number} amount - donation (forward) or refund (reverse)
+ * @param {'forward'|'reverse'} [mode='forward']
  */
-export function pushStateToUrl(province, income, donation) {
-  const params = new URLSearchParams({ province, income, donation });
+export function pushStateToUrl(province, income, amount, mode = 'forward') {
+  const params = new URLSearchParams({ province, income });
+  if (mode === 'reverse') {
+    params.set('mode', 'reverse');
+    params.set('refund', amount);
+  } else {
+    // Forward mode: no 'mode' param in URL — preserves existing URL format
+    // for backward compatibility with shared links and bookmarks.
+    params.set('donation', amount);
+  }
   history.pushState(null, "", `?${params}`);
 }
 
 /**
- * Read calculator inputs from the current URL.
- * @returns {object|null} { province, income, donation } or null if params missing/invalid
+ * Parse URL state from a query string. Pure function, testable without a browser.
+ * @param {string} search - query string including leading "?"
+ * @returns {object|null} Parsed state or null if params missing/invalid
  */
-export function readStateFromUrl() {
-  const params = new URLSearchParams(window.location.search);
+export function parseUrlState(search) {
+  const params = new URLSearchParams(search);
   const province = params.get("province");
   const income = params.get("income");
-  const donation = params.get("donation");
 
-  if (!province || !income || !donation) return null;
+  // Default to "forward" when mode param is absent — existing forward-mode URLs
+  // (shared links, bookmarks) don't have a mode param and must keep working.
+  const mode = params.get("mode") || "forward";
+
+  if (!province || !income) return null;
 
   const incomeNum = Number(income);
-  const donationNum = Number(donation);
-  if (isNaN(incomeNum) || isNaN(donationNum) || incomeNum < 0 || donationNum <= 0) {
-    return null;
+  if (isNaN(incomeNum) || incomeNum < 0) return null;
+
+  if (mode === "reverse") {
+    const refund = params.get("refund");
+    if (!refund) return null;
+    const refundNum = Number(refund);
+    if (isNaN(refundNum) || refundNum <= 0) return null;
+    return { mode: "reverse", province, income: incomeNum, refund: refundNum };
   }
 
-  return { province, income: incomeNum, donation: donationNum };
+  // Forward mode (explicit "forward" or any unknown value — treat as forward)
+  const donation = params.get("donation");
+  if (!donation) return null;
+  const donationNum = Number(donation);
+  if (isNaN(donationNum) || donationNum <= 0) return null;
+  return { mode: "forward", province, income: incomeNum, donation: donationNum };
+}
+
+/**
+ * Read calculator inputs from the current URL.
+ * @returns {object|null} Parsed state or null if params missing/invalid
+ */
+export function readStateFromUrl() {
+  return parseUrlState(window.location.search);
+}
+
+/**
+ * Push a mode-only URL with no calculator inputs.
+ *
+ * Used when the user switches to reverse mode via the segmented control
+ * before filling in any form fields. Creates a history entry so the
+ * browser Back button can undo the mode switch.
+ *
+ * Forward mode uses clearUrl() instead (a clean "/" is the app's default
+ * state — no need for an explicit mode param).
+ *
+ * @param {'reverse'} mode
+ */
+export function pushModeToUrl(mode) {
+  const params = new URLSearchParams({ mode });
+  history.pushState(null, "", `?${params}`);
 }
 
 /**

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -86,6 +86,27 @@ const scenarios = [
   },
 ];
 
+const reverseScenarios = [
+  {
+    name: "14-reverse-mode-full-benefit",
+    province: "Ontario",
+    income: "80000",
+    refund: 100,
+  },
+  {
+    name: "15-reverse-mode-partial",
+    province: "Ontario",
+    income: "16000",
+    refund: 200,
+  },
+  {
+    name: "16-reverse-mode-not-possible",
+    province: "Ontario",
+    income: "10000",
+    refund: 100,
+  },
+];
+
 for (const scenario of scenarios) {
   test(scenario.name, async ({ page }) => {
     await page.goto("/");
@@ -98,6 +119,37 @@ for (const scenario of scenarios) {
       await page.click(".btn-calculate");
       await page.waitForSelector(".results-section");
     }
+
+    await page.screenshot({
+      path: join(outputDir, `${scenario.name}.png`),
+      fullPage: true,
+    });
+  });
+}
+
+for (const scenario of reverseScenarios) {
+  test(scenario.name, async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("#calculator-form");
+
+    // Switch to reverse mode
+    await page.click('.mode-toggle button[data-mode="reverse"]');
+    await page.waitForSelector("#reverse-view:not([hidden])");
+
+    // Fill inputs
+    await page.selectOption("#rev-province", { label: scenario.province });
+    await page.fill("#rev-income", scenario.income);
+    await page.locator("#refund-slider").fill(String(scenario.refund));
+    await page.locator("#refund-slider").dispatchEvent("input");
+
+    // Wait for calculation to complete
+    await page.waitForFunction(
+      () => document.getElementById("donate-display").textContent.includes("$"),
+      { timeout: 5000 },
+    );
+
+    // Wait for breakdown bar width transitions (0.3s ease) to finish
+    await page.waitForTimeout(400);
 
     await page.screenshot({
       path: join(outputDir, `${scenario.name}.png`),

--- a/tests/e2e/features/navigation.feature
+++ b/tests/e2e/features/navigation.feature
@@ -58,6 +58,57 @@ Feature: Navigation
     And I should not see results
     And the URL should not contain "province"
 
+  # --- Mode switching and intra-route navigation ---
+
+  Scenario: Switching to reverse mode updates URL
+    Given I visit the calculator page
+    When I switch to reverse mode
+    Then I should see the reverse calculator
+    And the URL should contain "mode=reverse"
+
+  Scenario: Switching back to forward mode clears URL
+    Given I visit the calculator page
+    When I switch to reverse mode
+    And I switch to forward mode
+    Then I should see the forward calculator
+    And the URL should not contain "mode=reverse"
+    And the URL should not contain query parameters
+
+  Scenario: Back button restores forward mode after switching to reverse
+    Given I visit the calculator page
+    When I select "Ontario" as my province
+    And I enter "80000" as my income
+    And I enter "500" as my donation
+    And I click Calculate
+    Then I should see results
+    When I switch to reverse mode
+    Then the URL should contain "mode=reverse"
+    And I should not see results
+    When I press Back on the same page
+    Then I should see the forward calculator
+    And I should see results
+    And the URL should contain "donation=500"
+
+  Scenario: Back button restores reverse mode after switching to forward
+    When I visit the calculator with "?province=ON&income=80000&mode=reverse&refund=100"
+    Then I should see the reverse calculator
+    When I switch to forward mode
+    Then I should see the forward calculator
+    When I press Back on the same page
+    Then I should see the reverse calculator
+    And the URL should contain "mode=reverse"
+    And the URL should contain "refund=100"
+
+  Scenario: Deep link to bare reverse mode
+    When I visit the calculator with "?mode=reverse"
+    Then I should see the reverse calculator
+
+  Scenario: Deep link to full reverse state
+    When I visit the calculator with "?province=ON&income=80000&mode=reverse&refund=100"
+    Then I should see the reverse calculator
+    And the URL should contain "province=ON"
+    And the URL should contain "refund=100"
+
   # Flaky: history.back() timeout — see https://github.com/danielabar/charitable-tax-credit-calculator-canada/issues/11
   @fixme
   Scenario: Calculator state preserved after navigating away and back

--- a/tests/e2e/features/reverse-calculator.feature
+++ b/tests/e2e/features/reverse-calculator.feature
@@ -1,0 +1,81 @@
+Feature: Reverse calculator mode
+  Users can switch to reverse mode to find out how much they need to donate
+  to get a specific amount back. The slider provides live feedback based on
+  their province and income.
+
+  Background:
+    Given I visit the calculator page
+
+  # --- Slider: fully usable ---
+
+  Scenario: Slider shows donation needed for full taxpayer
+    When I switch to reverse mode
+    And I select "Ontario" as my reverse province
+    And I enter "80000" as my reverse income
+    And I set the refund slider to 100
+    Then the donate display should show a dollar amount
+    And the refund display should show "$100"
+    And there should be no slider warning
+    And the donation breakdown should be visible
+
+  # --- Slider: partly wasted ---
+
+  Scenario: Slider shows partial warning for low-income taxpayer
+    When I switch to reverse mode
+    And I select "Ontario" as my reverse province
+    And I enter "16000" as my reverse income
+    And I set the refund slider to 200
+    Then a partial credit warning should be visible
+    And the warning should mention the income needed
+
+  # --- Slider: entirely wasted ---
+
+  Scenario: Slider shows not-possible warning for non-taxpayer
+    When I switch to reverse mode
+    And I select "Ontario" as my reverse province
+    And I enter "10000" as my reverse income
+    And I set the refund slider to 100
+    Then a not-possible warning should be visible
+    And the refund display should show "$0"
+    And the warning should mention the income needed
+
+  # --- Optimistic mode (no income entered) ---
+
+  Scenario: Slider works without income in optimistic mode
+    When I switch to reverse mode
+    And I select "Ontario" as my reverse province
+    And I set the refund slider to 100
+    Then the donate display should show a dollar amount
+    And the refund display should show "$100"
+    And there should be no slider warning
+
+  # --- Forward mode still works after visiting reverse ---
+
+  Scenario: Forward calculator still works after visiting reverse mode
+    When I switch to reverse mode
+    And I switch to forward mode
+    And I select "Ontario" as my province
+    And I enter "80000" as my income
+    And I enter "500" as my donation
+    And I click Calculate
+    Then I should see results
+    And the bottom line should say "You get"
+
+  # --- URL state ---
+
+  Scenario: Reverse mode URL contains mode and refund params
+    When I switch to reverse mode
+    And I select "Ontario" as my reverse province
+    And I enter "80000" as my reverse income
+    And I set the refund slider to 100
+    Then the URL should contain "mode=reverse"
+    And the URL should contain "refund=100"
+    And the URL should contain "province=ON"
+
+  Scenario: Page hydrates reverse mode with form values from URL
+    When I visit the calculator with "?mode=reverse&province=ON&income=80000&refund=100"
+    Then I should see the reverse calculator
+    And the reverse province should show "Ontario"
+    And the reverse income should contain "80000"
+    And the refund slider should be at 100
+    And the donate display should show a dollar amount

--- a/tests/e2e/steps/navigation.js
+++ b/tests/e2e/steps/navigation.js
@@ -93,3 +93,52 @@ Then("I should not see results", async ({ page }) => {
 Then("the URL should not contain {string}", async ({ page }, text) => {
   expect(page.url()).not.toContain(text);
 });
+
+// --- Mode switching (forward ↔ reverse within the calculator route) ---
+
+When("I switch to reverse mode", async ({ page }) => {
+  await page.click('.mode-toggle button[data-mode="reverse"]');
+});
+
+When("I switch to forward mode", async ({ page }) => {
+  await page.click('.mode-toggle button[data-mode="forward"]');
+});
+
+Then("I should see the reverse calculator", async ({ page }) => {
+  await expect(page.locator("#reverse-view")).toBeVisible();
+  await expect(page.locator("#forward-view")).toBeHidden();
+});
+
+Then("I should see the forward calculator", async ({ page }) => {
+  await expect(page.locator("#forward-view")).toBeVisible();
+  await expect(page.locator("#reverse-view")).toBeHidden();
+});
+
+/**
+ * Navigate Back within the same SPA route (e.g. mode switch on "/").
+ *
+ * The standard "I go back in the browser" step waits for data-view to change,
+ * which works for cross-route navigation (/ → /about → back to /). But mode
+ * switches stay on the same route ("/") — data-view remains "calculator".
+ *
+ * This step waits for popstate to fire (URL changes), then uses networkidle
+ * to wait for the async popstate handler to finish rendering (it may call
+ * runCalculation or updateSlider which fetch config files).
+ */
+When("I press Back on the same page", async ({ page }) => {
+  const currentUrl = page.url();
+  await page.evaluate(() => {
+    return new Promise((resolve) => {
+      window.addEventListener("popstate", () => resolve(), { once: true });
+      history.back();
+    });
+  });
+  // Wait for URL to actually change before checking render
+  await page.waitForFunction(
+    (prevUrl) => window.location.href !== prevUrl,
+    currentUrl,
+    { timeout: 5000 },
+  );
+  // Wait for async popstate handler to finish (config fetches, rendering)
+  await page.waitForLoadState("networkidle");
+});

--- a/tests/e2e/steps/reverse-calculator.js
+++ b/tests/e2e/steps/reverse-calculator.js
@@ -1,0 +1,86 @@
+import { expect, When, Then } from "./fixtures.js";
+
+// --- Reverse form inputs ---
+
+When(
+  "I select {string} as my reverse province",
+  async ({ page }, province) => {
+    await page.selectOption("#rev-province", { label: province });
+  },
+);
+
+When("I enter {string} as my reverse income", async ({ page }, income) => {
+  await page.fill("#rev-income", income);
+});
+
+When("I set the refund slider to {int}", async ({ page }, value) => {
+  await page.locator("#refund-slider").fill(String(value));
+  await page.locator("#refund-slider").dispatchEvent("input");
+  // Wait for the async calculation to complete and update the display
+  await page.waitForFunction(
+    () => {
+      const el = document.getElementById("donate-display");
+      return el && el.textContent.includes("$");
+    },
+    { timeout: 5000 },
+  );
+});
+
+// --- Slider result assertions ---
+
+Then("the donate display should show a dollar amount", async ({ page }) => {
+  const display = page.locator("#donate-display");
+  await expect(display).toContainText("$");
+});
+
+Then("the refund display should show {string}", async ({ page }, text) => {
+  await expect(page.locator("#refund-display")).toContainText(text);
+});
+
+Then("there should be no slider warning", async ({ page }) => {
+  const warning = page.locator("#slider-warning");
+  await expect(warning).toBeEmpty();
+});
+
+Then("a not-possible warning should be visible", async ({ page }) => {
+  const warning = page.locator("#slider-warning .slider-warning");
+  await expect(warning).toBeVisible();
+});
+
+Then("a partial credit warning should be visible", async ({ page }) => {
+  const warning = page.locator("#slider-warning .slider-partial-warning");
+  await expect(warning).toBeVisible();
+});
+
+Then("the warning should mention the income needed", async ({ page }) => {
+  const warning = page.locator("#slider-warning");
+  await expect(warning).toContainText("need to earn");
+});
+
+Then("the donation breakdown should be visible", async ({ page }) => {
+  await expect(page.locator("#slider-breakdown")).toBeVisible();
+});
+
+Then("the refund slider should be at {int}", async ({ page }, value) => {
+  await expect(page.locator("#refund-slider")).toHaveValue(String(value));
+});
+
+// --- Reverse form hydration assertions ---
+
+Then(
+  "the reverse province should show {string}",
+  async ({ page }, expected) => {
+    const select = page.locator("#rev-province");
+    const selectedText = await select.evaluate(
+      (el) => el.options[el.selectedIndex].text,
+    );
+    expect(selectedText).toBe(expected);
+  },
+);
+
+Then(
+  "the reverse income should contain {string}",
+  async ({ page }, expected) => {
+    await expect(page.locator("#rev-income")).toHaveValue(expected);
+  },
+);

--- a/tests/e2e/steps/url-state.js
+++ b/tests/e2e/steps/url-state.js
@@ -4,7 +4,10 @@ When(
   "I visit the calculator with {string}",
   async ({ page }, queryString) => {
     await page.goto(`/${queryString}`);
-    await page.waitForSelector("#calculator-form");
+    // Wait for the calculator view to finish initializing, regardless of which
+    // mode (forward/reverse) is active. Can't use #calculator-form because it's
+    // hidden when the URL specifies mode=reverse.
+    await page.waitForSelector('#content[data-view="calculator"]');
   },
 );
 

--- a/tests/unit/reverse-calculation-pipeline.spec.js
+++ b/tests/unit/reverse-calculation-pipeline.spec.js
@@ -1,0 +1,130 @@
+/**
+ * Integration tests for the reverse calculation pipeline.
+ * Tests the composition: desiredRefund → donationNeeded → credit → usability check.
+ * Uses test fixture configs (federal: 10%/20%, Ontario: 5%/10%, threshold: $200).
+ */
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { calculateDonationForRefund } from "../../js/calculate-donation-for-refund.js";
+import { calculateTotalTax } from "../../js/calculate-total-tax.js";
+import { calculateDonationCredit } from "../../js/calculate-donation-credit.js";
+import { checkCreditUsability } from "../../js/check-credit-usability.js";
+import { calculateMinimumIncome } from "../../js/calculate-minimum-income.js";
+
+const federalConfig = JSON.parse(
+  readFileSync(join(process.cwd(), "config/tax-data/test/federal.json"), "utf-8")
+);
+const onConfig = JSON.parse(
+  readFileSync(join(process.cwd(), "config/tax-data/test/provinces/ON.json"), "utf-8")
+);
+
+// Test fixture rates:
+// Combined low rate = 15% (federal 10% + ON 5%), threshold = $200
+// Combined high rate = 30% (federal 20% + ON 10%)
+// Max credit from first $200 = $200 × 0.15 = $30
+// Federal BPA = 15000, ON BPA = 10000
+
+/**
+ * Run the reverse pipeline synchronously using the same sequence
+ * as runReverseCalculation in calculator.js.
+ */
+function runReversePipeline(income, desiredRefund) {
+  const donationNeeded = calculateDonationForRefund(desiredRefund, federalConfig, onConfig);
+  const tax = calculateTotalTax(income, federalConfig, onConfig);
+  const credit = calculateDonationCredit(donationNeeded, income, federalConfig, onConfig);
+  const usability = checkCreditUsability(credit.totalCredit, tax.totalTax, donationNeeded);
+
+  let minimumIncome = null;
+  if (usability.state !== "fully-usable") {
+    minimumIncome = calculateMinimumIncome(credit.totalCredit, federalConfig, onConfig);
+  }
+
+  return { donationNeeded, tax, credit, usability, minimumIncome };
+}
+
+test.describe("reverse pipeline — fully usable (high income)", () => {
+  test("$15 refund at $80K income → $100 donation, fully usable", () => {
+    const r = runReversePipeline(80000, 15);
+    expect(r.donationNeeded).toBe(100);
+    expect(r.usability.state).toBe("fully-usable");
+    expect(r.minimumIncome).toBeNull();
+  });
+
+  test("$30 refund at $80K income → $200 donation, fully usable", () => {
+    const r = runReversePipeline(80000, 30);
+    expect(r.donationNeeded).toBe(200);
+    expect(r.usability.state).toBe("fully-usable");
+  });
+
+  test("$45 refund at $80K income → $250 donation, fully usable", () => {
+    const r = runReversePipeline(80000, 45);
+    expect(r.donationNeeded).toBe(250);
+    expect(r.usability.state).toBe("fully-usable");
+  });
+});
+
+test.describe("reverse pipeline — entirely wasted (no tax owed)", () => {
+  test("$15 refund at $10K income → entirely wasted", () => {
+    // $10K is below the federal BPA ($15K), so no federal tax.
+    // $10K is also at the ON BPA ($10K), so $0 provincial tax.
+    const r = runReversePipeline(10000, 15);
+    expect(r.donationNeeded).toBe(100);
+    expect(r.tax.totalTax).toBe(0);
+    expect(r.usability.state).toBe("entirely-wasted");
+    expect(r.minimumIncome).not.toBeNull();
+    expect(r.minimumIncome).toBeGreaterThan(10000);
+  });
+});
+
+test.describe("reverse pipeline — partly wasted (low income)", () => {
+  test("$30 refund at $15.5K income → partly wasted", () => {
+    // $15.5K: above ON BPA ($10K) so some provincial tax, above or below federal BPA ($15K)
+    // Federal: $15.5K - $15K = $500 taxable × 10% = $50
+    // Ontario: $15.5K - $10K = $5500 taxable × 5% = $275
+    // Total tax = $325
+    // $30 refund → $200 donation → credit = $200 × 0.15 = $30
+    // Credit ($30) < tax ($325) → fully usable
+    const r = runReversePipeline(15500, 30);
+    expect(r.donationNeeded).toBe(200);
+    expect(r.usability.state).toBe("fully-usable");
+  });
+
+  test("$45 refund at $10.2K income → partly wasted (tax > 0 but < credit)", () => {
+    // $10.2K: below federal BPA ($15K) so $0 federal tax.
+    // Ontario: $10.2K - $10K = $200 taxable × 5% = $10 provincial tax.
+    // Total tax = $10
+    // $45 refund → $250 donation → credit = $200×0.15 + $50×0.30 = $30 + $15 = $45
+    // Credit ($45) > tax ($10) → partly wasted
+    const r = runReversePipeline(10200, 45);
+    expect(r.donationNeeded).toBe(250);
+    expect(r.tax.totalTax).toBe(10);
+    expect(r.usability.state).toBe("partly-wasted");
+    expect(r.usability.creditUsable).toBe(10);
+    expect(r.usability.creditWasted).toBe(35);
+    expect(r.minimumIncome).not.toBeNull();
+  });
+});
+
+test.describe("reverse pipeline — round-trip verification", () => {
+  test("donation for $15 refund produces credit >= $15", () => {
+    const donation = calculateDonationForRefund(15, federalConfig, onConfig);
+    const credit = calculateDonationCredit(donation, 80000, federalConfig, onConfig);
+    expect(credit.totalCredit).toBeGreaterThanOrEqual(15);
+    expect(credit.totalCredit).toBeLessThan(17);
+  });
+
+  test("donation for $45 refund produces credit >= $45", () => {
+    const donation = calculateDonationForRefund(45, federalConfig, onConfig);
+    const credit = calculateDonationCredit(donation, 80000, federalConfig, onConfig);
+    expect(credit.totalCredit).toBeGreaterThanOrEqual(45);
+    expect(credit.totalCredit).toBeLessThan(47);
+  });
+
+  test("donation for $60 refund produces credit >= $60", () => {
+    const donation = calculateDonationForRefund(60, federalConfig, onConfig);
+    const credit = calculateDonationCredit(donation, 80000, federalConfig, onConfig);
+    expect(credit.totalCredit).toBeGreaterThanOrEqual(60);
+    expect(credit.totalCredit).toBeLessThan(62);
+  });
+});

--- a/tests/unit/smoke-current-year.spec.js
+++ b/tests/unit/smoke-current-year.spec.js
@@ -72,4 +72,21 @@ test.describe("smoke — current year (2026)", () => {
     // but not much more (at most ~$1 overshoot from rounding)
     expect(credit.totalCredit).toBeLessThan(target + 2);
   });
+
+  test("reverse pipeline: $100 refund at $80K ON is fully usable", () => {
+    const donation = calculateDonationForRefund(100, federalConfig, onConfig);
+    const tax = calculateTotalTax(80000, federalConfig, onConfig);
+    const credit = calculateDonationCredit(donation, 80000, federalConfig, onConfig);
+    const usability = checkCreditUsability(credit.totalCredit, tax.totalTax, donation);
+    expect(usability.state).toBe("fully-usable");
+    expect(credit.totalCredit).toBeGreaterThanOrEqual(100);
+  });
+
+  test("reverse pipeline: $100 refund at $13K ON is partly or entirely wasted", () => {
+    const donation = calculateDonationForRefund(100, federalConfig, onConfig);
+    const tax = calculateTotalTax(13000, federalConfig, onConfig);
+    const credit = calculateDonationCredit(donation, 13000, federalConfig, onConfig);
+    const usability = checkCreditUsability(credit.totalCredit, tax.totalTax, donation);
+    expect(usability.state).toMatch(/partly-wasted|entirely-wasted/);
+  });
 });

--- a/tests/unit/url-state.spec.js
+++ b/tests/unit/url-state.spec.js
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for URL state parsing (parseUrlState).
+ * Tests the pure parsing function extracted from readStateFromUrl.
+ */
+import { test, expect } from "@playwright/test";
+import { parseUrlState } from "../../js/ui/url-state.js";
+
+test.describe("parseUrlState — forward mode", () => {
+  test("parses forward URL with all params", () => {
+    const result = parseUrlState("?province=ON&income=60000&donation=500");
+    expect(result).toEqual({
+      mode: "forward",
+      province: "ON",
+      income: 60000,
+      donation: 500,
+    });
+  });
+
+  test("explicit mode=forward works the same", () => {
+    const result = parseUrlState("?mode=forward&province=ON&income=60000&donation=500");
+    expect(result).toEqual({
+      mode: "forward",
+      province: "ON",
+      income: 60000,
+      donation: 500,
+    });
+  });
+
+  test("backward compat: no mode param defaults to forward", () => {
+    const result = parseUrlState("?province=BC&income=45000&donation=200");
+    expect(result.mode).toBe("forward");
+  });
+
+  test("returns null when donation is missing", () => {
+    expect(parseUrlState("?province=ON&income=60000")).toBeNull();
+  });
+
+  test("returns null when province is missing", () => {
+    expect(parseUrlState("?income=60000&donation=500")).toBeNull();
+  });
+
+  test("returns null when income is missing", () => {
+    expect(parseUrlState("?province=ON&donation=500")).toBeNull();
+  });
+
+  test("returns null for non-numeric income", () => {
+    expect(parseUrlState("?province=ON&income=abc&donation=500")).toBeNull();
+  });
+
+  test("returns null for zero donation", () => {
+    expect(parseUrlState("?province=ON&income=60000&donation=0")).toBeNull();
+  });
+
+  test("returns null for negative donation", () => {
+    expect(parseUrlState("?province=ON&income=60000&donation=-100")).toBeNull();
+  });
+
+  test("allows zero income", () => {
+    const result = parseUrlState("?province=ON&income=0&donation=500");
+    expect(result).not.toBeNull();
+    expect(result.income).toBe(0);
+  });
+
+  test("returns null for negative income", () => {
+    expect(parseUrlState("?province=ON&income=-1000&donation=500")).toBeNull();
+  });
+});
+
+test.describe("parseUrlState — reverse mode", () => {
+  test("parses reverse URL with all params", () => {
+    const result = parseUrlState("?mode=reverse&province=ON&income=60000&refund=100");
+    expect(result).toEqual({
+      mode: "reverse",
+      province: "ON",
+      income: 60000,
+      refund: 100,
+    });
+  });
+
+  test("returns null when refund is missing in reverse mode", () => {
+    expect(parseUrlState("?mode=reverse&province=ON&income=60000")).toBeNull();
+  });
+
+  test("returns null for zero refund", () => {
+    expect(parseUrlState("?mode=reverse&province=ON&income=60000&refund=0")).toBeNull();
+  });
+
+  test("returns null for negative refund", () => {
+    expect(parseUrlState("?mode=reverse&province=ON&income=60000&refund=-50")).toBeNull();
+  });
+
+  test("returns null for non-numeric refund", () => {
+    expect(parseUrlState("?mode=reverse&province=ON&income=60000&refund=abc")).toBeNull();
+  });
+
+  test("allows zero income in reverse mode", () => {
+    const result = parseUrlState("?mode=reverse&province=ON&income=0&refund=100");
+    expect(result).not.toBeNull();
+    expect(result.income).toBe(0);
+  });
+});
+
+test.describe("parseUrlState — unknown mode", () => {
+  test("unknown mode treats as forward", () => {
+    const result = parseUrlState("?mode=bogus&province=ON&income=60000&donation=500");
+    expect(result).toEqual({
+      mode: "forward",
+      province: "ON",
+      income: 60000,
+      donation: 500,
+    });
+  });
+});
+
+test.describe("parseUrlState — empty/no params", () => {
+  test("empty string returns null", () => {
+    expect(parseUrlState("")).toBeNull();
+  });
+
+  test("just a question mark returns null", () => {
+    expect(parseUrlState("?")).toBeNull();
+  });
+});

--- a/views/calculator/script.js
+++ b/views/calculator/script.js
@@ -1,15 +1,109 @@
-import { setupForm, clearAllErrors } from "../../js/ui/form.js";
-import { runCalculation } from "../../js/calculator.js";
+import { setupForm, clearAllErrors, parseCurrency } from "../../js/ui/form.js";
+import { runCalculation, runReverseCalculation } from "../../js/calculator.js";
 import { renderResults } from "../../js/ui/results.js";
-import { pushStateToUrl, readStateFromUrl, clearUrl } from "../../js/ui/url-state.js";
+import { pushStateToUrl, pushModeToUrl, readStateFromUrl, clearUrl } from "../../js/ui/url-state.js";
+import { loadAppSettings } from "../../js/load-config.js";
+import { calculateDonationForRefund } from "../../js/calculate-donation-for-refund.js";
+import { loadFederalConfig, loadProvinceConfig } from "../../js/load-config.js";
+import { formatCurrency } from "../../js/format.js";
+import { buildReverseWarning } from "../../js/ui/reverse-narrative.js";
+
+let debounceTimer = null;
+// Guard against popstate firing after this view is destroyed. Both the router
+// and this view listen for popstate. When navigating to a different route,
+// the router's handler calls destroy() — but removeEventListener during an
+// event dispatch doesn't cancel already-queued handlers for the same event,
+// so this flag prevents the stale handler from running.
+let destroyed = false;
+// Stored reference so destroy() can remove the listener that init() registers.
+let popstateHandler = null;
+
+function debounce(fn, ms) {
+  return (...args) => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => fn(...args), ms);
+  };
+}
 
 export async function init(contentEl, html) {
   contentEl.innerHTML = html;
 
+  // --- Load slider config from app-settings.json ---
+  const appSettings = await loadAppSettings();
+  const sliderConfig = appSettings.reverseSlider;
+  const slider = document.getElementById("refund-slider");
+  slider.min = sliderConfig.min;
+  slider.max = sliderConfig.max;
+  slider.value = sliderConfig.defaultValue;
+  slider.step = sliderConfig.step;
+  document.getElementById("slider-label-min").textContent = `$${sliderConfig.min}`;
+  document.getElementById("slider-label-mid").textContent = `$${Math.round((sliderConfig.min + sliderConfig.max) / 2)}`;
+  document.getElementById("slider-label-max").textContent = `$${sliderConfig.max}`;
+
+  // --- Shared elements ---
   const form = document.getElementById("calculator-form");
   const resultsContainer = document.getElementById("results-container");
   const startOverBtn = form.querySelector(".btn-start-over");
 
+  // --- Mode toggle ---
+  const modeButtons = document.querySelectorAll(".mode-toggle button");
+  const forwardView = document.getElementById("forward-view");
+  const reverseView = document.getElementById("reverse-view");
+  let currentMode = "forward";
+  destroyed = false;
+
+  /**
+   * Pure UI toggle — updates button states and view visibility.
+   *
+   * This is the foundation that both user-initiated switches (switchMode)
+   * and browser history restoration (onPopState) build on. It has NO URL
+   * side effects, so callers control whether a history entry is created.
+   *
+   * Always clears results and hides "Start Over" when switching modes,
+   * because stale results from the previous mode would be confusing.
+   */
+  function setModeUI(mode) {
+    currentMode = mode;
+    modeButtons.forEach(b => {
+      const isActive = b.dataset.mode === mode;
+      b.classList.toggle("active", isActive);
+      b.setAttribute("aria-selected", String(isActive));
+    });
+    forwardView.hidden = mode !== "forward";
+    reverseView.hidden = mode !== "reverse";
+    resultsContainer.innerHTML = "";
+    startOverBtn.hidden = true;
+  }
+
+  /**
+   * Handle user-initiated mode switch (clicking the segmented control).
+   *
+   * Updates the UI via setModeUI, then pushes a new history entry so the
+   * browser Back button can undo the mode switch. The URL reflects the new
+   * mode even before the user fills in any form fields:
+   *   - Forward: "/" (clean URL, no params)
+   *   - Reverse: "?mode=reverse" (mode-only, no province/income/refund yet)
+   *
+   * This is intentionally separate from setModeUI because history restoration
+   * via onPopState must NOT push new entries — doing so would corrupt the
+   * history stack the user is navigating through.
+   */
+  function switchMode(mode) {
+    setModeUI(mode);
+    if (mode === "reverse") {
+      pushModeToUrl("reverse");
+    } else {
+      clearUrl();
+    }
+  }
+
+  modeButtons.forEach(b => b.addEventListener("click", () => {
+    if (b.dataset.mode === currentMode) return;
+    switchMode(b.dataset.mode);
+    if (b.dataset.mode === "reverse") updateSlider();
+  }));
+
+  // --- Forward mode (existing logic, unchanged) ---
   async function calculate(province, income, donation) {
     const results = await runCalculation(province, income, donation);
     await renderResults(results);
@@ -29,16 +123,209 @@ export async function init(contentEl, html) {
     clearUrl();
   });
 
-  // Hydrate from URL if query params are present
+  // --- Reverse mode (slider) ---
+  const revProvince = document.getElementById("rev-province");
+  const revIncome = document.getElementById("rev-income");
+  const targetDisplay = document.getElementById("target-display");
+  const donateDisplay = document.getElementById("donate-display");
+  const refundDisplay = document.getElementById("refund-display");
+  const sliderResult = document.getElementById("slider-result");
+  const sliderBreakdown = document.getElementById("slider-breakdown");
+  const warningContainer = document.getElementById("slider-warning");
+  const segLow = document.getElementById("seg-low");
+  const segHigh = document.getElementById("seg-high");
+  const legendLow = document.getElementById("legend-low");
+  const legendHigh = document.getElementById("legend-high");
+
+  async function updateSlider() {
+    const province = revProvince.value;
+    const incomeStr = revIncome.value;
+    const income = parseCurrency(incomeStr);
+    const refund = parseInt(slider.value);
+
+    // Always update the target display
+    targetDisplay.textContent = `$${refund}`;
+
+    if (!province) {
+      // No province selected — show placeholder state
+      donateDisplay.textContent = "—";
+      refundDisplay.textContent = "—";
+      warningContainer.innerHTML = "";
+      sliderResult.classList.remove("dimmed");
+      sliderBreakdown.classList.remove("dimmed");
+      segLow.style.width = "0%";
+      segHigh.style.width = "0%";
+      legendLow.textContent = "";
+      legendHigh.textContent = "";
+      return;
+    }
+
+    if (incomeStr.trim() === "" || isNaN(income)) {
+      // Province selected but no income — optimistic mode (assume full taxpayer)
+      const [federal, prov] = await Promise.all([
+        loadFederalConfig(),
+        loadProvinceConfig(province),
+      ]);
+      const donationNeeded = calculateDonationForRefund(refund, federal, prov);
+      updateSliderUI(refund, donationNeeded, null, federal, prov);
+      return;
+    }
+
+    const results = await runReverseCalculation(province, income, refund);
+    const [federal, prov] = await Promise.all([
+      loadFederalConfig(),
+      loadProvinceConfig(province),
+    ]);
+    updateSliderUI(refund, results.donationNeeded, results, federal, prov);
+    pushStateToUrl(province, income, refund, "reverse");
+  }
+
+  function updateSliderUI(refund, donationNeeded, results, federal, prov) {
+    const threshold = federal.donationCredit.lowRateThreshold;
+
+    // Donation display
+    donateDisplay.textContent = formatCurrency(donationNeeded);
+
+    // Breakdown bar
+    const lowPortion = Math.min(donationNeeded, threshold);
+    const highPortion = Math.max(0, donationNeeded - threshold);
+    const total = donationNeeded || 1;
+    segLow.style.width = `${(lowPortion / total * 100).toFixed(1)}%`;
+    segHigh.style.width = `${(highPortion / total * 100).toFixed(1)}%`;
+    segLow.textContent = lowPortion > 0 ? formatCurrency(lowPortion) : "";
+    segHigh.textContent = highPortion > 0 ? formatCurrency(highPortion) : "";
+    legendLow.textContent = `First $${threshold} at lower rate`;
+    legendHigh.textContent = highPortion > 0 ? `Above $${threshold} at higher rate` : "";
+
+    if (!results) {
+      // Optimistic mode — no income, assume full taxpayer
+      refundDisplay.textContent = formatCurrency(refund);
+      refundDisplay.className = "srb-amount refund-val";
+      warningContainer.innerHTML = "";
+      sliderResult.classList.remove("dimmed");
+      sliderBreakdown.classList.remove("dimmed");
+      return;
+    }
+
+    // Full results available — check usability
+    const { usability } = results;
+
+    if (usability.state === "fully-usable") {
+      refundDisplay.textContent = formatCurrency(refund);
+      refundDisplay.className = "srb-amount refund-val";
+      warningContainer.innerHTML = "";
+      sliderResult.classList.remove("dimmed");
+      sliderBreakdown.classList.remove("dimmed");
+    } else if (usability.state === "entirely-wasted") {
+      refundDisplay.textContent = "$0";
+      refundDisplay.className = "srb-amount refund-val";
+      refundDisplay.style.color = "var(--color-wasted)";
+      warningContainer.innerHTML = buildReverseWarning(results);
+      sliderResult.classList.add("dimmed");
+      sliderBreakdown.classList.add("dimmed");
+    } else {
+      // partly-wasted
+      refundDisplay.textContent = formatCurrency(usability.creditUsable);
+      refundDisplay.className = "srb-amount refund-val";
+      refundDisplay.style.color = "var(--color-accent)";
+      warningContainer.innerHTML = buildReverseWarning(results);
+      sliderResult.classList.remove("dimmed");
+      sliderBreakdown.classList.remove("dimmed");
+    }
+  }
+
+  slider.addEventListener("input", updateSlider);
+  revIncome.addEventListener("input", debounce(updateSlider, 300));
+  revProvince.addEventListener("change", updateSlider);
+
+  // --- URL hydration ---
+  // Restore calculator state from URL query params on initial load.
+  // Uses setModeUI (not switchMode) because we're restoring state that's
+  // already in the URL — pushing a new history entry would double it.
   const state = readStateFromUrl();
-  if (state) {
+  if (state?.mode === "reverse") {
+    setModeUI("reverse");
+    revProvince.value = state.province;
+    revIncome.value = state.income;
+    slider.value = Math.min(Math.max(state.refund, sliderConfig.min), sliderConfig.max);
+    await updateSlider();
+  } else if (state) {
     form.querySelector("#province").value = state.province;
     form.querySelector("#income").value = state.income;
     form.querySelector("#donation").value = state.donation;
     await calculate(state.province, state.income, state.donation);
+  } else {
+    // No full state parseable — check for bare mode param.
+    // Handles deep links like "?mode=reverse" (reverse mode, empty form).
+    const params = new URLSearchParams(location.search);
+    if (params.get("mode") === "reverse") {
+      setModeUI("reverse");
+      await updateSlider();
+    }
   }
+
+  // --- Popstate handler for intra-route navigation ---
+  /**
+   * Restore calculator state when the user navigates via browser Back/Forward.
+   *
+   * The SPA router (js/router.js) has a same-route guard: when popstate fires
+   * and the route path hasn't changed (still "/"), the router skips re-init.
+   * This means mode switches and form submissions — which change query params
+   * but not the route — are invisible to the router. This handler fills that gap.
+   *
+   * Uses setModeUI (not switchMode) to avoid pushing a new history entry,
+   * which would corrupt the history stack the user is navigating through.
+   *
+   * The `destroyed` guard prevents this handler from running after the view
+   * has been torn down. See the comment on the `destroyed` variable for details.
+   */
+  async function onPopState() {
+    if (destroyed) return;
+
+    const popState = readStateFromUrl();
+    if (popState?.mode === "reverse") {
+      // Full reverse state — restore form fields and recalculate
+      setModeUI("reverse");
+      revProvince.value = popState.province;
+      revIncome.value = popState.income;
+      slider.value = Math.min(Math.max(popState.refund, sliderConfig.min), sliderConfig.max);
+      await updateSlider();
+    } else if (popState) {
+      // Full forward state — restore form fields and recalculate
+      setModeUI("forward");
+      form.querySelector("#province").value = popState.province;
+      form.querySelector("#income").value = popState.income;
+      form.querySelector("#donation").value = popState.donation;
+      await calculate(popState.province, popState.income, popState.donation);
+    } else {
+      // No full state parseable — check for bare mode param.
+      // Handles history entries like "?mode=reverse" (reverse toggled, form empty)
+      // or "/" (forward mode, form empty / start-over).
+      const params = new URLSearchParams(location.search);
+      if (params.get("mode") === "reverse") {
+        setModeUI("reverse");
+        revProvince.value = "";
+        revIncome.value = "";
+        slider.value = sliderConfig.defaultValue;
+        await updateSlider();
+      } else {
+        setModeUI("forward");
+        form.reset();
+        clearAllErrors(form);
+      }
+    }
+  }
+
+  // Register after hydration so the initial state is fully established first.
+  popstateHandler = onPopState;
+  window.addEventListener("popstate", popstateHandler);
 }
 
 export function destroy() {
-  // Cleanup when navigating away
+  destroyed = true;
+  clearTimeout(debounceTimer);
+  if (popstateHandler) {
+    window.removeEventListener("popstate", popstateHandler);
+    popstateHandler = null;
+  }
 }

--- a/views/calculator/template.html
+++ b/views/calculator/template.html
@@ -4,13 +4,71 @@
     <p>The only calculator that tells you whether you can really use the tax credit — and what to do if you can't.</p>
   </div>
 
-  <div class="input-card">
-    <h2>Your information</h2>
+  <div class="tab-card">
+  <div class="mode-toggle" role="tablist">
+    <button class="active" data-mode="forward" role="tab" aria-selected="true" aria-controls="forward-view">What do I get back?</button>
+    <button data-mode="reverse" role="tab" aria-selected="false" aria-controls="reverse-view">How much should I donate?</button>
+  </div>
 
-    <form id="calculator-form" novalidate>
+  <!-- Forward mode: existing calculator (unchanged) -->
+  <div id="forward-view" class="tab-panel-card" role="tabpanel">
+    <div class="input-card">
+      <h2>Your information</h2>
+
+      <form id="calculator-form" novalidate>
+        <div class="form-group">
+          <label for="province">Province or territory</label>
+          <select id="province" name="province" required>
+            <option value="">Select your province...</option>
+            <option value="AB">Alberta</option>
+            <option value="BC">British Columbia</option>
+            <option value="MB">Manitoba</option>
+            <option value="NB">New Brunswick</option>
+            <option value="NL">Newfoundland and Labrador</option>
+            <option value="NS">Nova Scotia</option>
+            <option value="NT">Northwest Territories</option>
+            <option value="NU">Nunavut</option>
+            <option value="ON">Ontario</option>
+            <option value="PE">Prince Edward Island</option>
+            <option value="SK">Saskatchewan</option>
+            <option value="YT">Yukon</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="income">Annual income</label>
+          <div class="hint">Your salary or wages before deductions</div>
+          <div class="input-prefix">
+            <input type="text" id="income" name="income" inputmode="numeric" placeholder="0" required>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="donation">Donation amount</label>
+          <div class="hint">Total amount from your charitable donation receipt(s)</div>
+          <div class="input-prefix">
+            <input type="text" id="donation" name="donation" inputmode="numeric" placeholder="0" required>
+          </div>
+        </div>
+
+        <div class="form-buttons">
+          <button type="submit" class="btn-calculate">Calculate your credit</button>
+          <button type="button" class="btn-start-over" hidden>Start over</button>
+        </div>
+      </form>
+    </div>
+
+    <div id="results-container" aria-live="polite">
+    </div>
+  </div>
+
+  <!-- Reverse mode: slider widget -->
+  <div id="reverse-view" class="tab-panel-card" hidden role="tabpanel">
+    <div class="input-card">
+      <h2>Your information</h2>
       <div class="form-group">
-        <label for="province">Province or territory</label>
-        <select id="province" name="province" required>
+        <label for="rev-province">Province or territory</label>
+        <select id="rev-province" required>
           <option value="">Select your province...</option>
           <option value="AB">Alberta</option>
           <option value="BC">British Columbia</option>
@@ -26,30 +84,63 @@
           <option value="YT">Yukon</option>
         </select>
       </div>
-
       <div class="form-group">
-        <label for="income">Annual income</label>
+        <label for="rev-income">Annual income</label>
         <div class="hint">Your salary or wages before deductions</div>
         <div class="input-prefix">
-          <input type="text" id="income" name="income" inputmode="numeric" placeholder="0" required>
+          <input type="text" id="rev-income" inputmode="numeric" placeholder="0">
+        </div>
+      </div>
+    </div>
+
+    <div class="slider-widget">
+      <div class="slider-question">
+        I want to get back
+        <span class="slider-target-amount" id="target-display">$100</span>
+      </div>
+
+      <div class="slider-container">
+        <input type="range" class="slider-input" id="refund-slider"
+               min="10" max="500" value="100" step="1">
+        <div class="slider-labels">
+          <span id="slider-label-min">$10</span>
+          <span id="slider-label-mid">$250</span>
+          <span id="slider-label-max">$500</span>
         </div>
       </div>
 
-      <div class="form-group">
-        <label for="donation">Donation amount</label>
-        <div class="hint">Total amount from your charitable donation receipt(s)</div>
-        <div class="input-prefix">
-          <input type="text" id="donation" name="donation" inputmode="numeric" placeholder="0" required>
+      <div id="slider-warning" aria-live="polite"></div>
+
+      <div class="slider-result" id="slider-result">
+        <div class="slider-result-box">
+          <div class="srb-label">You donate</div>
+          <div class="srb-amount donate-val" id="donate-display">—</div>
+        </div>
+        <div class="slider-result-arrow">&rarr;</div>
+        <div class="slider-result-box">
+          <div class="srb-label">You get back</div>
+          <div class="srb-amount refund-val" id="refund-display">—</div>
         </div>
       </div>
 
-      <div class="form-buttons">
-        <button type="submit" class="btn-calculate">Calculate your credit</button>
-        <button type="button" class="btn-start-over" hidden>Start over</button>
+      <div class="breakdown" id="slider-breakdown">
+        <div class="breakdown-title">How your donation breaks down</div>
+        <div class="breakdown-bar">
+          <div class="seg-low" id="seg-low"></div>
+          <div class="seg-high" id="seg-high"></div>
+        </div>
+        <div class="breakdown-legend">
+          <div class="legend-item">
+            <div class="legend-swatch swatch-low"></div>
+            <span id="legend-low"></span>
+          </div>
+          <div class="legend-item">
+            <div class="legend-swatch swatch-high"></div>
+            <span id="legend-high"></span>
+          </div>
+        </div>
       </div>
-    </form>
+    </div>
   </div>
-
-  <div id="results-container" aria-live="polite">
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Adds a reverse calculator mode toggled via connected tabs on the calculator page — users enter province, income, and desired refund (via interactive slider), and get the required donation amount with a visual credit breakdown
- Reuses the full forward calculation pipeline in reverse order, so reverse mode inherits all non-refundable credit honesty (warnings when income is too low to use the full credit)
- Extends URL state with `mode=reverse` and `refund` param for shareable/bookmarkable reverse results and correct Back button navigation
- Adds reverse-specific narrative warning banners (partial usability, zero tax, low income) with links to the Learn page
- Slider range and steps are config-driven via `app-settings.json`

## Test plan

- [x] Unit tests for reverse calculation pipeline
- [x] Unit tests for extended URL state (reverse mode params)
- [x] Smoke tests for reverse mode against real config
- [x] E2E tests for mode switching and slider interaction
- [x] E2E tests for navigation (Back button between modes)
- [x] Screenshot scenarios for visual regression
- [ ] Manual testing: verify slider feel and warning banners across provinces
- [ ] Manual testing: verify shareable URLs round-trip correctly

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)