### PR TITLE
[#17] Reduce vertical spacing in results for better information density

### DIFF
--- a/css/inputs.css
+++ b/css/inputs.css
@@ -1,6 +1,6 @@
 @layer components {
   .form-group {
-    margin-bottom: 20px;
+    margin-bottom: var(--space-md);
   }
 
   .form-group label {

--- a/css/layout.css
+++ b/css/layout.css
@@ -12,7 +12,7 @@
   }
 
   .hero {
-    padding: var(--space-2xl) 0 12px;
+    padding: var(--space-xl) 0 8px;
   }
 
   .hero h1 {
@@ -34,7 +34,7 @@
     background: var(--color-bg);
     border: 1px solid var(--color-border);
     border-radius: var(--radius);
-    padding: var(--space-xl);
+    padding: var(--space-lg);
     margin: var(--space-lg) 0 0;
   }
 
@@ -44,11 +44,11 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--color-text-secondary);
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
   }
 
   .results-section {
-    padding: 40px 0 60px;
+    padding: 28px 0 40px;
   }
 
   @media (max-width: 640px) {

--- a/css/narrative.css
+++ b/css/narrative.css
@@ -6,12 +6,12 @@
   .narrative h2 {
     font-size: 22px;
     font-weight: 700;
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
     letter-spacing: -0.3px;
   }
 
   .narrative-section {
-    padding: 20px 0;
+    padding: 14px 0;
     border-bottom: 1px solid var(--color-border);
   }
 
@@ -33,7 +33,7 @@
   }
 
   .narrative-section p + p {
-    margin-top: 10px;
+    margin-top: 8px;
   }
 
   /* Highlighted amounts */
@@ -55,8 +55,8 @@
   /* Callout boxes */
   .callout {
     border-radius: var(--radius);
-    padding: 20px var(--space-lg);
-    margin: var(--space-md) 0;
+    padding: 16px 20px;
+    margin: 12px 0;
     font-size: 15px;
     line-height: 1.6;
   }

--- a/css/results.css
+++ b/css/results.css
@@ -3,8 +3,8 @@
   .big-number-card {
     background: var(--color-bg-alt);
     border-radius: var(--radius);
-    padding: 36px var(--space-xl);
-    margin-bottom: var(--space-xl);
+    padding: 24px var(--space-xl);
+    margin-bottom: var(--space-lg);
     text-align: center;
   }
 
@@ -45,7 +45,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: var(--space-md);
-    margin-bottom: var(--space-xl);
+    margin-bottom: var(--space-lg);
   }
 
   .summary-grid.three-col {
@@ -55,7 +55,7 @@
   .summary-item {
     background: var(--color-bg-alt);
     border-radius: var(--radius);
-    padding: 20px;
+    padding: var(--space-md);
   }
 
   .summary-item .label {
@@ -89,7 +89,7 @@
 
   /* Credit vs tax bar */
   .bar-chart {
-    margin-bottom: 36px;
+    margin-bottom: var(--space-lg);
   }
 
   .bar-chart .bar-label {
@@ -168,8 +168,8 @@
   .disclaimer {
     background: var(--color-bg-alt);
     border-radius: var(--radius);
-    padding: var(--space-lg);
-    margin-top: var(--space-xl);
+    padding: 20px;
+    margin-top: var(--space-lg);
     font-size: 13px;
     color: var(--color-text-secondary);
     line-height: 1.7;


### PR DESCRIPTION
## Summary

- Tighten padding and margins across the results area (hero, input card, big number card, summary grid, bar chart, narrative sections, callouts, disclaimer) while keeping the form area spacious
- Saves ~200–270px on a typical results page — roughly one fewer scroll on 1080p
- Creates a natural shift from "invitation" (the form) to "report" (the results) by using denser spacing in the results section
- Pure CSS changes across 4 files — no HTML or structural changes

Closes #17

## Test plan

- [x] Visually inspected full-page screenshots of all 17 app states (blank form, full benefit, partly wasted, entirely wasted, top bracket, reverse mode, learn page)
- [ ] Run `npm run test` to verify no regressions
- [ ] Check on mobile viewport (640px) for any cramped layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)