### PR TITLE
Soften credit limitation language from "wasted/lost" to "unused"

### DIFF
--- a/js/ui/narrative.js
+++ b/js/ui/narrative.js
@@ -161,10 +161,10 @@ async function buildNonRefundableSection(results) {
 
   if (usability.state === UsabilityState.ENTIRELY_WASTED) {
     const calloutHtml = await callout("warning",
-      `The charitable tax credit is <strong>non-refundable</strong>. It can reduce the tax you owe, but it can't go below zero. Since your estimated tax is already $0, the entire <span class="hl-red">${$(credit.totalCredit)}</span> credit has nothing to reduce. It disappears.`
+      `The charitable tax credit is <strong>non-refundable</strong>. It can reduce the tax you owe, but it can't go below zero. Since your estimated tax is already $0, the entire <span class="hl-red">${$(credit.totalCredit)}</span> credit has nothing to reduce. It goes unused.`
     );
     return section("non-refundable",
-      `<h3>Why the credit doesn't help this year</h3>
+      `<h3>Why the credit can't be used this year</h3>
 ${calloutHtml}
 <p>This is a limitation of how the system is designed, not a reflection of your generosity. Many people are in this situation and most existing calculators don't mention it.</p>
 <a href="learn" data-route="/learn" class="learn-link">See how this affects different types of taxpayers <span class="arrow">&rarr;</span></a>`
@@ -172,10 +172,10 @@ ${calloutHtml}
   }
 
   const calloutHtml = await callout("warning",
-    `Your donation credit of <span class="hl-red">${$(credit.totalCredit)}</span> is larger than your estimated tax of <span class="hl">${$(tax.totalTax)}</span>. The credit can reduce your tax to $0, saving you ${$(usability.creditUsable)}. But the remaining <span class="hl-red">${$(usability.creditWasted)}</span> of credit disappears — it can't be refunded to you. This is what "non-refundable" means.`
+    `Your donation credit of <span class="hl-red">${$(credit.totalCredit)}</span> is larger than your estimated tax of <span class="hl">${$(tax.totalTax)}</span>. The credit can reduce your tax to $0, saving you ${$(usability.creditUsable)}. But the remaining <span class="hl-red">${$(usability.creditWasted)}</span> of credit goes unused — it can't be refunded to you. This is what "non-refundable" means.`
   );
   return section("non-refundable",
-    `<h3>Why part of your credit is lost</h3>
+    `<h3>Why part of your credit goes unused</h3>
 ${calloutHtml}
 <p>This isn't about you — it's how the system works. The charitable tax credit can only reduce tax you already owe. It can never create a refund on its own.</p>
 <a href="learn" data-route="/learn" class="learn-link">See how this affects different types of taxpayers <span class="arrow">&rarr;</span></a>`
@@ -208,7 +208,7 @@ async function buildCarryForwardSection(results) {
     ),
   ]);
   return section("carry-forward",
-    `<h3>What you can do about it</h3>\n${carryCallout}\n${spouseCallout}`
+    `<h3>Your options</h3>\n${carryCallout}\n${spouseCallout}`
   );
 }
 

--- a/js/ui/results.js
+++ b/js/ui/results.js
@@ -36,7 +36,7 @@ function buildHeadline(results) {
         colorClass: "positive",
         headlineLabel: `Your ${donation} donation to charity`,
         headlineNumber: `You get ${savings} back`,
-        headlineContext: `Your credit would be ${total}, but you only owe ${taxOwed} in tax — so that's all that comes back to you. The remaining ${wasted} is lost.`,
+        headlineContext: `Your credit would be ${total}, but you only owe ${taxOwed} in tax — so that's all that comes back to you. The remaining ${wasted} can't be used this year.`,
       };
     }
     case UsabilityState.ENTIRELY_WASTED:
@@ -78,7 +78,7 @@ async function buildSummaryGrid(results) {
         { label: "Credit calculated", value: formatCurrency(credit.totalCredit), className: "teal" },
         { label: "Your estimated tax", value: formatCurrency(tax.totalTax), className: "muted" },
         { label: "You get back", value: formatCurrency(usability.creditUsable), className: "teal" },
-        { label: "Lost", value: formatCurrency(usability.creditWasted), className: "red", highlight: true },
+        { label: "Unused", value: formatCurrency(usability.creditWasted), className: "red", highlight: true },
       ];
       break;
     case UsabilityState.ENTIRELY_WASTED:
@@ -87,7 +87,7 @@ async function buildSummaryGrid(results) {
         { label: "Credit calculated", value: formatCurrency(credit.totalCredit), className: "muted" },
         { label: "Your estimated tax", value: formatCurrency(tax.totalTax), className: "muted" },
         { label: "You get back", value: "$0", className: "muted" },
-        { label: "Lost", value: formatCurrency(credit.totalCredit), className: "red", highlight: true },
+        { label: "Unused", value: formatCurrency(credit.totalCredit), className: "red", highlight: true },
       ];
       break;
   }
@@ -136,11 +136,11 @@ async function buildBarChart(results) {
       const wastedPercent = 100 - usablePercent;
       const segments = [
         fillTemplate(segmentTemplate, { segmentClass: "usable", width: String(usablePercent), segmentLabel: `${formatCurrency(usability.creditUsable)} back to you` }),
-        fillTemplate(segmentTemplate, { segmentClass: "wasted", width: String(wastedPercent), segmentLabel: `${formatCurrency(usability.creditWasted)} lost` }),
+        fillTemplate(segmentTemplate, { segmentClass: "wasted", width: String(wastedPercent), segmentLabel: `${formatCurrency(usability.creditWasted)} unused` }),
       ].join("\n");
       const legend = [
         fillTemplate(legendTemplate, { legendClass: "usable", legendLabel: "Back to you" }),
-        fillTemplate(legendTemplate, { legendClass: "wasted", legendLabel: "Lost (non-refundable)" }),
+        fillTemplate(legendTemplate, { legendClass: "wasted", legendLabel: "Unused (exceeds tax)" }),
       ].join("\n");
       return fillTemplate(chartTemplate, { barLabel: `Your ${formatCurrency(credit.totalCredit)} credit vs. your ${formatCurrency(usability.estimatedTax)} tax`, segments, legend });
     }

--- a/tests/e2e/features/donor-experience.feature
+++ b/tests/e2e/features/donor-experience.feature
@@ -111,7 +111,7 @@ Feature: Donor experience
     # Disclaimer
     And the disclaimer should be shown
 
-  Scenario: Credit partly wasted — donation above $200
+  Scenario: Credit partly unused — donation above $200
     When I select "Ontario" as my province
     And I enter "13000" as my income
     And I enter "500" as my donation
@@ -121,9 +121,9 @@ Feature: Donor experience
     And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount unused
     # Visual breakdown
-    And the visual breakdown should show usable versus wasted credit
+    And the visual breakdown should show usable versus unused credit
     # Narrative
     And the explanation should show tiered rates for donations above $200
     And the tax situation should say income is mostly sheltered by the basic personal amount
@@ -137,7 +137,7 @@ Feature: Donor experience
     # Disclaimer
     And the disclaimer should be shown
 
-  Scenario: Credit partly wasted — donation near $200 (nudge suppressed)
+  Scenario: Credit partly unused — donation near $200 (nudge suppressed)
     When I select "Ontario" as my province
     And I enter "13000" as my income
     And I enter "180" as my donation
@@ -147,9 +147,9 @@ Feature: Donor experience
     And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount unused
     # Visual breakdown
-    And the visual breakdown should show usable versus wasted credit
+    And the visual breakdown should show usable versus unused credit
     # Narrative
     And the explanation should show a single rate for donations under $200
     And the tax situation should say income is mostly sheltered by the basic personal amount
@@ -157,13 +157,13 @@ Feature: Donor experience
     And the results should include carry-forward and spouse options
     And the results should include the minimum income section
     And the results should include a learn link in the non-refundable section
-    # Critical: nudge must NOT appear — credit is already partly wasted
+    # Critical: nudge must NOT appear — credit is already partly unused
     And the results should not include the $200 threshold nudge
     And the results should not include the closing encouragement
     # Disclaimer
     And the disclaimer should be shown
 
-  Scenario: Credit partly wasted — donation well below $200
+  Scenario: Credit partly unused — donation well below $200
     When I select "Ontario" as my province
     And I enter "13000" as my income
     And I enter "100" as my donation
@@ -173,9 +173,9 @@ Feature: Donor experience
     And the bottom line should say "back"
     And the bottom line should not show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount unused
     # Visual breakdown
-    And the visual breakdown should show usable versus wasted credit
+    And the visual breakdown should show usable versus unused credit
     # Narrative
     And the explanation should show a single rate for donations under $200
     And the tax situation should say income is mostly sheltered by the basic personal amount
@@ -183,13 +183,13 @@ Feature: Donor experience
     And the results should include carry-forward and spouse options
     And the results should include the minimum income section
     And the results should include a learn link in the non-refundable section
-    # No nudge — credit wasted AND far from $200
+    # No nudge — credit unused AND far from $200
     And the results should not include the $200 threshold nudge
     And the results should not include the closing encouragement
     # Disclaimer
     And the disclaimer should be shown
 
-  Scenario: Credit entirely wasted — donation above $200
+  Scenario: Credit entirely unused — donation above $200
     When I select "Ontario" as my province
     And I enter "10000" as my income
     And I enter "500" as my donation
@@ -198,8 +198,8 @@ Feature: Donor experience
     Then the bottom line should say "You get $0 back"
     And the bottom line should show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
-    # No visual breakdown for entirely wasted
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount unused
+    # No visual breakdown for entirely unused
     And there should be no visual breakdown
     # Narrative
     And the explanation should show tiered rates for donations above $200
@@ -210,12 +210,12 @@ Feature: Donor experience
     And the results should include the closing encouragement
     And the results should include a learn link in the non-refundable section
     And the results should include a learn link in the closing section
-    # No nudge — all credit is wasted
+    # No nudge — all credit is unused
     And the results should not include the $200 threshold nudge
     # Disclaimer
     And the disclaimer should be shown
 
-  Scenario: Credit entirely wasted — donation near $200 (nudge suppressed)
+  Scenario: Credit entirely unused — donation near $200 (nudge suppressed)
     When I select "Ontario" as my province
     And I enter "10000" as my income
     And I enter "180" as my donation
@@ -224,7 +224,7 @@ Feature: Donor experience
     Then the bottom line should say "You get $0 back"
     And the bottom line should show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount unused
     # No visual breakdown
     And there should be no visual breakdown
     # Narrative
@@ -236,12 +236,12 @@ Feature: Donor experience
     And the results should include the closing encouragement
     And the results should include a learn link in the non-refundable section
     And the results should include a learn link in the closing section
-    # Critical: nudge must NOT appear — entire credit is wasted
+    # Critical: nudge must NOT appear — entire credit is unused
     And the results should not include the $200 threshold nudge
     # Disclaimer
     And the disclaimer should be shown
 
-  Scenario: Credit entirely wasted — donation well below $200
+  Scenario: Credit entirely unused — donation well below $200
     When I select "Ontario" as my province
     And I enter "10000" as my income
     And I enter "100" as my donation
@@ -250,7 +250,7 @@ Feature: Donor experience
     Then the bottom line should say "You get $0 back"
     And the bottom line should show a warning
     # Credit summary
-    And the credit summary should show credit calculated, estimated tax, amount back, and amount lost
+    And the credit summary should show credit calculated, estimated tax, amount back, and amount unused
     # No visual breakdown
     And there should be no visual breakdown
     # Narrative
@@ -262,7 +262,7 @@ Feature: Donor experience
     And the results should include the closing encouragement
     And the results should include a learn link in the non-refundable section
     And the results should include a learn link in the closing section
-    # No nudge — credit wasted AND far from $200
+    # No nudge — credit unused AND far from $200
     And the results should not include the $200 threshold nudge
     # Disclaimer
     And the disclaimer should be shown

--- a/tests/e2e/features/reverse-calculator.feature
+++ b/tests/e2e/features/reverse-calculator.feature
@@ -19,7 +19,7 @@ Feature: Reverse calculator mode
     And the donation breakdown should be visible
     And the disclaimer should be shown
 
-  # --- Slider: partly wasted ---
+  # --- Slider: partly unused ---
 
   Scenario: Slider shows partial warning for low-income taxpayer
     When I switch to reverse mode
@@ -30,7 +30,7 @@ Feature: Reverse calculator mode
     And the warning should mention the income needed
     And the disclaimer should be shown
 
-  # --- Slider: entirely wasted ---
+  # --- Slider: entirely unused ---
 
   Scenario: Slider shows not-possible warning for non-taxpayer
     When I switch to reverse mode

--- a/tests/e2e/steps/donor-experience.js
+++ b/tests/e2e/steps/donor-experience.js
@@ -41,7 +41,7 @@ Then(
 );
 
 Then(
-  "the credit summary should show credit calculated, estimated tax, amount back, and amount lost",
+  "the credit summary should show credit calculated, estimated tax, amount back, and amount unused",
   async ({ page }) => {
     const grid = page.locator(".summary-grid");
     await expect(grid).toBeVisible();
@@ -51,7 +51,7 @@ Then(
     await expect(items.nth(0).locator(".label")).toContainText("Credit calculated");
     await expect(items.nth(1).locator(".label")).toContainText("estimated tax");
     await expect(items.nth(2).locator(".label")).toContainText("You get back");
-    await expect(items.nth(3).locator(".label")).toContainText("Lost");
+    await expect(items.nth(3).locator(".label")).toContainText("Unused");
     // Lost amount should be highlighted
     await expect(items.nth(3)).toHaveClass(/highlight-bad/);
   },
@@ -72,7 +72,7 @@ Then(
 );
 
 Then(
-  "the visual breakdown should show usable versus wasted credit",
+  "the visual breakdown should show usable versus unused credit",
   async ({ page }) => {
     const chart = page.locator(".bar-chart");
     await expect(chart).toBeVisible();

--- a/views/about/template.html
+++ b/views/about/template.html
@@ -2,10 +2,10 @@
   <h1>About this calculator</h1>
 
   <p>Most charitable tax credit calculators show you a number and call it a day. They don't check whether you actually owe enough tax to use the credit. This tool does.</p>
-  <p>Charitable donation tax credits in Canada are <strong>non-refundable</strong> — they reduce your tax owing, but can never push it below zero. If your income is low enough that you don't owe much tax, part or all of your credit may go to waste. We think you should know that before you file.</p>
+  <p>Charitable donation tax credits in Canada are <strong>non-refundable</strong> — they reduce your tax owing, but can never push it below zero. If your income is low enough that you don't owe much tax, part or all of your credit may go unused. We think you should know that before you file.</p>
 
   <h2>How the calculation works</h2>
-  <p>We estimate your federal and provincial income tax using your income and the basic personal amount. Then we calculate your charitable donation tax credit and compare it to your estimated tax. If the credit exceeds your tax, we show you exactly how much would be wasted and what your options are.</p>
+  <p>We estimate your federal and provincial income tax using your income and the basic personal amount. Then we calculate your charitable donation tax credit and compare it to your estimated tax. If the credit exceeds your tax, we show you exactly how much would go unused and what your options are.</p>
 
   <h2>What we assume</h2>
   <ul>
@@ -17,7 +17,7 @@
   </ul>
 
   <h2>What this means for you</h2>
-  <p>Our estimated tax will generally be <strong>higher</strong> than your actual tax, since most people have credits we don't account for (CPP/EI contributions, employment amount, age amount, and others). So when we warn that a credit may go to waste because your tax is too low, the real situation could be <strong>even more limiting</strong> than what we show.</p>
+  <p>Our estimated tax will generally be <strong>higher</strong> than your actual tax, since most people have credits we don't account for (CPP/EI contributions, employment amount, age amount, and others). So when we warn that a credit may go unused because your tax is too low, the real situation could be <strong>even more limiting</strong> than what we show.</p>
 
   <h2>Open source</h2>
   <p>This tool is free and open source. You can review the code, report issues, or contribute on <a href="https://github.com/danielabar/charitable-tax-credit-calculator-canada" target="_blank" rel="noopener">GitHub</a>.</p>

--- a/views/learn/template.html
+++ b/views/learn/template.html
@@ -18,7 +18,7 @@
           </div>
         </div>
         <div class="card-body">
-          Owes $0 in tax. The credit has nothing to reduce — it disappears entirely.
+          Owes $0 in tax. The credit has nothing to reduce — it goes entirely unused.
         </div>
         <div class="scenario-detail">
           <div class="detail-item">
@@ -46,7 +46,7 @@
               <div class="result-amount zero">{{nonTaxpayer_getsBack}}</div>
             </div>
           </div>
-          <div class="result-detail">Credit entirely wasted</div>
+          <div class="result-detail">Credit can't be used</div>
         </div>
       </div>
 
@@ -88,7 +88,7 @@
               <div class="result-amount partial">{{partialTaxpayer_getsBack}}</div>
             </div>
           </div>
-          <div class="result-detail">Only usable portion offsets tax — rest of credit lost</div>
+          <div class="result-detail">Only usable portion offsets tax — rest of credit unused</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replaces negative framing ("wasted", "lost", "disappears") with neutral language ("unused", "goes unused", "can't be used") across all user-facing text
- Based on feedback from a financial planner who noted that "credit wasted" language may discourage low-income donors by implying their *donation* was wasted, not just the tax benefit
- Internal code names (`PARTLY_WASTED`, CSS classes, etc.) are unchanged — developer-only, not worth the churn

## Files changed
- `js/ui/results.js` — headline context, summary grid labels, bar chart labels
- `js/ui/narrative.js` — section headings, callout text
- `views/learn/template.html` — scenario card labels
- `views/about/template.html` — descriptive paragraphs
- `tests/e2e/` — updated step text, scenario names, and comments to match

## Test plan
- [ ] Run full test suite (`npm test`)
- [ ] Visual review of partly-unused and entirely-unused scenarios in the calculator
- [ ] Review Learn page scenario cards for updated language
- [ ] Review About page paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)