### PR TITLE
[#34] Show soft warning when donation exceeds 75% of income

### DIFF
--- a/config/app-settings.json
+++ b/config/app-settings.json
@@ -12,5 +12,6 @@
   "inputLimits": {
     "income": { "min": 0, "max": 500000 },
     "donation": { "min": 1, "max": 250000 }
-  }
+  },
+  "donationClaimLimitPercent": 0.75
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,8 @@ Config files are fetched via `js/load-config.js`, which caches them after the fi
   "inputLimits": {
     "income": { "min": 0, "max": 500000 },
     "donation": { "min": 1, "max": 250000 }
-  }
+  },
+  "donationClaimLimitPercent": 0.75
 }
 ```
 
@@ -48,6 +49,7 @@ Config files are fetched via `js/load-config.js`, which caches them after the fi
 | `inputLimits.income.max` | number | `500000` | Maximum allowed income value |
 | `inputLimits.donation.min` | number | `1` | Minimum allowed donation value |
 | `inputLimits.donation.max` | number | `250000` | Maximum allowed donation value |
+| `donationClaimLimitPercent` | number (0–1) | `0.75` | CRA annual claiming limit as percentage of net income. Triggers an informational warning when the donation exceeds this percentage of the user's entered income. Based on ITA Section 118.1. |
 
 ## Learn config reference
 

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -12,6 +12,7 @@ import { calculateMinimumIncome } from "./calculate-minimum-income.js";
 import { calculateNudge } from "./calculate-nudge.js";
 import { calculateDonationForRefund } from "./calculate-donation-for-refund.js";
 import { calculateSurtaxSavings } from "./calculate-surtax-savings.js";
+import { checkDonationClaimLimit } from "./check-donation-claim-limit.js";
 
 /**
  * @typedef {object} CalculationResults
@@ -43,6 +44,7 @@ import { calculateSurtaxSavings } from "./calculate-surtax-savings.js";
  * @property {number} nudge.hypotheticalAmount
  * @property {number} nudge.hypotheticalCredit
  * @property {number} nudge.currentCredit
+ * @property {{ exceedsLimit: boolean }} claimLimit
  * @property {object} donationRates
  * @property {number} donationRates.threshold
  * @property {{lowRate: number, highRate: number, topRate: number, topRateThreshold: number}} donationRates.federal
@@ -86,6 +88,8 @@ export async function runCalculation(provinceCode, income, donationAmount) {
     tax.totalTax, tax.provincialTax, usability.state, credit.effectiveTotalCredit
   );
 
+  const claimLimit = checkDonationClaimLimit(donationAmount, income, appSettings.donationClaimLimitPercent);
+
   const donationRates = {
     threshold: federal.donationCredit.lowRateThreshold,
     federal: {
@@ -107,6 +111,7 @@ export async function runCalculation(provinceCode, income, donationAmount) {
     usability,
     minimumIncome,
     nudge,
+    claimLimit,
     donationRates,
     appSettings,
   };

--- a/js/check-donation-claim-limit.js
+++ b/js/check-donation-claim-limit.js
@@ -1,0 +1,12 @@
+/**
+ * Check if a donation exceeds the CRA annual claiming limit.
+ * @param {number} donation
+ * @param {number} income - The user's entered income (gross, not net)
+ * @param {number} limitPercent - e.g. 0.75
+ * @returns {{ exceedsLimit: boolean }}
+ */
+export function checkDonationClaimLimit(donation, income, limitPercent) {
+  return {
+    exceedsLimit: income > 0 && donation > income * limitPercent,
+  };
+}

--- a/js/ui/narrative.js
+++ b/js/ui/narrative.js
@@ -65,6 +65,10 @@ async function buildAllSections(results) {
     sections.push(await buildThresholdNudgeSection(results));
   }
 
+  if (results.claimLimit?.exceedsLimit) {
+    sections.push(await buildClaimLimitSection());
+  }
+
   if (results.usability.state === UsabilityState.PARTLY_WASTED || results.usability.state === UsabilityState.ENTIRELY_WASTED) {
     sections.push(await buildNonRefundableSection(results));
     sections.push(await buildCarryForwardSection(results));
@@ -136,6 +140,19 @@ ${calloutHtml}
 <p>This doesn't mean you should donate more than you want to. But if you're planning to give more later this year, it's worth knowing that each dollar above $${threshold} works harder for you.</p>`;
 
   return section("threshold-nudge", content);
+}
+
+async function buildClaimLimitSection() {
+  const calloutHtml = await callout("warm",
+    `<strong>Your donation may exceed the annual claiming limit.</strong> The CRA limits the charitable donation amount you can claim to 75% of your net income per tax year. Any amount over the limit can be carried forward and claimed over the next 5 years.`
+  );
+
+  return section("claim-limit",
+    `<h3>CRA annual claiming limit</h3>
+${calloutHtml}
+<p>The credit shown above is calculated on your full donation. In practice, you may need to spread the claim across multiple tax years.</p>
+<p style="font-size:13px; color:var(--color-text-secondary); margin-top: 8px;">The CRA limit is based on your net income (line 23600), which is your income after deductions like RRSP contributions. This may be lower than the income you entered above. Use CRA's Schedule 9 when filing for the exact calculation.</p>`
+  );
 }
 
 async function buildTaxSituationSection(results) {

--- a/js/ui/narrative.js
+++ b/js/ui/narrative.js
@@ -72,7 +72,13 @@ async function buildAllSections(results) {
   if (results.usability.state === UsabilityState.PARTLY_WASTED || results.usability.state === UsabilityState.ENTIRELY_WASTED) {
     sections.push(await buildNonRefundableSection(results));
     sections.push(await buildCarryForwardSection(results));
-    sections.push(await buildMinimumIncomeSection(results));
+
+    // Skip minimum income when the 75% claim limit also fires — telling the
+    // user "earn $X to use it all in one year" is misleading when they need
+    // to spread the claim across years anyway.
+    if (!results.claimLimit?.exceedsLimit) {
+      sections.push(await buildMinimumIncomeSection(results));
+    }
   }
 
   if (results.usability.state === UsabilityState.ENTIRELY_WASTED) {
@@ -180,7 +186,7 @@ async function buildTaxSituationSection(results) {
 }
 
 async function buildNonRefundableSection(results) {
-  const { credit, tax, usability } = results;
+  const { credit, tax, usability, input, claimLimit } = results;
 
   if (usability.state === UsabilityState.ENTIRELY_WASTED) {
     const calloutHtml = await callout("warning",
@@ -190,6 +196,21 @@ async function buildNonRefundableSection(results) {
       `<h3>Why the credit can't be used this year</h3>
 ${calloutHtml}
 <p>This is a limitation of how the system is designed, not a reflection of your generosity. Many people are in this situation and most existing calculators don't mention it.</p>
+<a href="learn" data-route="/learn" class="learn-link">See how this affects different types of taxpayers <span class="arrow">&rarr;</span></a>`
+    );
+  }
+
+  // When the 75% claim limit also fires, reframe the non-refundable section
+  // to connect with the "spread your claim" advice instead of presenting
+  // a separate alarming warning.
+  if (claimLimit?.exceedsLimit) {
+    const calloutHtml = await callout("info",
+      `The charitable donation credit is <strong>non-refundable</strong> — it can reduce tax you owe, but it can never create a refund on its own. If you were to claim the full <span class="hl">${$(input.donationAmount)}</span> donation in a single year, the credit of <span class="hl">${$(credit.effectiveTotalCredit)}</span> would exceed your estimated tax of <span class="hl">${$(tax.totalTax)}</span> — and <span class="hl-red">${$(usability.creditWasted)}</span> of credit would go unused.`
+    );
+    return section("non-refundable",
+      `<h3>Why spreading your claim also helps with the credit</h3>
+${calloutHtml}
+<p>By spreading the claim across multiple years, each year's credit is smaller and more likely to fit within that year's tax — so less goes to waste.</p>
 <a href="learn" data-route="/learn" class="learn-link">See how this affects different types of taxpayers <span class="arrow">&rarr;</span></a>`
     );
   }
@@ -218,6 +239,18 @@ async function buildCarryForwardSection(results) {
     ]);
     return section("carry-forward",
       `<h3>What you can do</h3>\n${carryCallout}\n${spouseCallout}`
+    );
+  }
+
+  // When the 75% claim limit also fires, carry-forward advice has already
+  // been covered by the claim limit section — only show the spouse option.
+  if (results.claimLimit?.exceedsLimit) {
+    const spouseCallout = await callout("info",
+      `<strong>Let your spouse claim it.</strong> If your spouse or common-law partner has a higher income, they may be able to use more of the credit in a single year. Either spouse can claim any donation, regardless of who made it.`,
+      "spouse-option"
+    );
+    return section("carry-forward",
+      `<h3>Another option</h3>\n${spouseCallout}`
     );
   }
 

--- a/js/ui/narrative.js
+++ b/js/ui/narrative.js
@@ -210,7 +210,7 @@ ${calloutHtml}
     return section("non-refundable",
       `<h3>Why spreading your claim also helps with the credit</h3>
 ${calloutHtml}
-<p>By spreading the claim across multiple years, each year's credit is smaller and more likely to fit within that year's tax — so less goes to waste.</p>
+<p>By spreading the claim across multiple years, each year's credit is smaller and more likely to fit within that year's tax — so less credit goes unused.</p>
 <a href="learn" data-route="/learn" class="learn-link">See how this affects different types of taxpayers <span class="arrow">&rarr;</span></a>`
     );
   }

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -94,6 +94,12 @@ const scenarios = [
     donation: "120000",
   },
   {
+    name: "19-claim-limit-plus-unused-credit",
+    province: "Ontario",
+    income: "100000",
+    donation: "95000",
+  },
+  {
     name: "12-top-bracket-below-200",
     province: "Ontario",
     income: "300000",

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -88,6 +88,12 @@ const scenarios = [
     donation: "5000",
   },
   {
+    name: "18-claim-limit-warning",
+    province: "Ontario",
+    income: "150000",
+    donation: "120000",
+  },
+  {
     name: "12-top-bracket-below-200",
     province: "Ontario",
     income: "300000",

--- a/tests/e2e/features/donation-claim-limit.feature
+++ b/tests/e2e/features/donation-claim-limit.feature
@@ -21,6 +21,11 @@ Feature: CRA 75% donation claiming limit warning
     And the warning should mention "75% of your net income"
     And the warning should mention "carried forward"
     And the warning should mention "Schedule 9"
+    And the non-refundable section should mention "spreading your claim"
+    And the non-refundable section should mention "If you were to claim the full"
+    And the carry-forward section should not mention "Carry it forward"
+    And the carry-forward section should mention "Let your spouse claim it"
+    And I should not see the minimum income section
 
   Scenario: Forward mode — donation exactly at 75% shows no warning
     When I select "Ontario" as my province

--- a/tests/e2e/features/donation-claim-limit.feature
+++ b/tests/e2e/features/donation-claim-limit.feature
@@ -1,0 +1,31 @@
+Feature: CRA 75% donation claiming limit warning
+
+  Background:
+    Given I visit the calculator page
+
+  Scenario: Forward mode — donation under 75% of income shows no warning
+    When I select "Ontario" as my province
+    And I enter "150000" as my income
+    And I enter "50000" as my donation
+    And I click Calculate
+    Then the results should appear
+    And I should not see the CRA claiming limit warning
+
+  Scenario: Forward mode — donation over 75% of income shows warning
+    When I select "Ontario" as my province
+    And I enter "150000" as my income
+    And I enter "120000" as my donation
+    And I click Calculate
+    Then the results should appear
+    And I should see the CRA claiming limit warning
+    And the warning should mention "75% of your net income"
+    And the warning should mention "carried forward"
+    And the warning should mention "Schedule 9"
+
+  Scenario: Forward mode — donation exactly at 75% shows no warning
+    When I select "Ontario" as my province
+    And I enter "100000" as my income
+    And I enter "75000" as my donation
+    And I click Calculate
+    Then the results should appear
+    And I should not see the CRA claiming limit warning

--- a/tests/e2e/steps/donation-claim-limit.js
+++ b/tests/e2e/steps/donation-claim-limit.js
@@ -1,0 +1,18 @@
+import { expect, Then } from "./fixtures.js";
+
+Then("the results should appear", async ({ page }) => {
+  await expect(page.locator(".results-section")).toBeVisible();
+});
+
+Then("I should see the CRA claiming limit warning", async ({ page }) => {
+  await expect(page.locator('[data-narrative="claim-limit"]')).toBeVisible();
+});
+
+Then("I should not see the CRA claiming limit warning", async ({ page }) => {
+  await expect(page.locator('[data-narrative="claim-limit"]')).toHaveCount(0);
+});
+
+Then("the warning should mention {string}", async ({ page }, text) => {
+  const section = page.locator('[data-narrative="claim-limit"]');
+  await expect(section).toContainText(text);
+});

--- a/tests/e2e/steps/donation-claim-limit.js
+++ b/tests/e2e/steps/donation-claim-limit.js
@@ -16,3 +16,22 @@ Then("the warning should mention {string}", async ({ page }, text) => {
   const section = page.locator('[data-narrative="claim-limit"]');
   await expect(section).toContainText(text);
 });
+
+Then("the non-refundable section should mention {string}", async ({ page }, text) => {
+  const section = page.locator('[data-narrative="non-refundable"]');
+  await expect(section).toContainText(text);
+});
+
+Then("the carry-forward section should not mention {string}", async ({ page }, text) => {
+  const section = page.locator('[data-narrative="carry-forward"]');
+  await expect(section).not.toContainText(text);
+});
+
+Then("the carry-forward section should mention {string}", async ({ page }, text) => {
+  const section = page.locator('[data-narrative="carry-forward"]');
+  await expect(section).toContainText(text);
+});
+
+Then("I should not see the minimum income section", async ({ page }) => {
+  await expect(page.locator('[data-narrative="minimum-income"]')).toHaveCount(0);
+});

--- a/tests/unit/check-donation-claim-limit.spec.js
+++ b/tests/unit/check-donation-claim-limit.spec.js
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { checkDonationClaimLimit } from "../../js/check-donation-claim-limit.js";
+
+test.describe("checkDonationClaimLimit", () => {
+  test("under limit — returns false", () => {
+    const result = checkDonationClaimLimit(50000, 100000, 0.75);
+    expect(result.exceedsLimit).toBe(false);
+  });
+
+  test("exactly at limit — returns false", () => {
+    const result = checkDonationClaimLimit(75000, 100000, 0.75);
+    expect(result.exceedsLimit).toBe(false);
+  });
+
+  test("over limit — returns true", () => {
+    const result = checkDonationClaimLimit(75001, 100000, 0.75);
+    expect(result.exceedsLimit).toBe(true);
+  });
+
+  test("way over limit — returns true", () => {
+    const result = checkDonationClaimLimit(100000, 100000, 0.75);
+    expect(result.exceedsLimit).toBe(true);
+  });
+
+  test("zero income, positive donation — returns false", () => {
+    const result = checkDonationClaimLimit(500, 0, 0.75);
+    expect(result.exceedsLimit).toBe(false);
+  });
+
+  test("zero donation — returns false", () => {
+    const result = checkDonationClaimLimit(0, 100000, 0.75);
+    expect(result.exceedsLimit).toBe(false);
+  });
+
+  test("small donation, small income — over limit returns true", () => {
+    const result = checkDonationClaimLimit(800, 1000, 0.75);
+    expect(result.exceedsLimit).toBe(true);
+  });
+});

--- a/tests/unit/smoke-current-year.spec.js
+++ b/tests/unit/smoke-current-year.spec.js
@@ -11,6 +11,7 @@ import { calculateDonationCredit } from "../../js/calculate-donation-credit.js";
 import { checkCreditUsability } from "../../js/check-credit-usability.js";
 import { calculateDonationForRefund } from "../../js/calculate-donation-for-refund.js";
 import { calculateSurtaxSavings } from "../../js/calculate-surtax-savings.js";
+import { checkDonationClaimLimit } from "../../js/check-donation-claim-limit.js";
 
 const federalConfig = JSON.parse(
   readFileSync(join(process.cwd(), "config/tax-data/2026/federal.json"), "utf-8")
@@ -24,10 +25,12 @@ test.describe("smoke — current year (2026)", () => {
     const tax = calculateTotalTax(80000, federalConfig, onConfig);
     const credit = calculateDonationCredit(500, 80000, federalConfig, onConfig);
     const usability = checkCreditUsability(credit.totalCredit, tax.totalTax, 500);
+    const claimLimit = checkDonationClaimLimit(500, 80000, 0.75);
 
     expect(credit.totalCredit).toBeGreaterThan(100);
     expect(credit.totalCredit).toBeLessThan(250);
     expect(usability.state).toBe("fully-usable");
+    expect(claimLimit.exceedsLimit).toBe(false);
   });
 
   test("low income ON ($13K, $500 donation)", () => {
@@ -60,6 +63,16 @@ test.describe("smoke — current year (2026)", () => {
     // At $80K, provincial tax is well above surtax thresholds, but credit is small
     // so surtaxSavings should be > 0 (credit reduces tax that's in surtax range)
     expect(surtaxSavings).toBeGreaterThanOrEqual(0);
+  });
+
+  test("high income ON ($150K, $120K donation) — donation exceeds 75% claim limit", () => {
+    const tax = calculateTotalTax(150000, federalConfig, onConfig);
+    const credit = calculateDonationCredit(120000, 150000, federalConfig, onConfig);
+    const usability = checkCreditUsability(credit.totalCredit, tax.totalTax, 120000);
+    const claimLimit = checkDonationClaimLimit(120000, 150000, 0.75);
+
+    expect(credit.totalCredit).toBeGreaterThan(20000);
+    expect(claimLimit.exceedsLimit).toBe(true);
   });
 
   test("zero donation returns zero credit", () => {

--- a/tests/unit/tax-data-validation.spec.js
+++ b/tests/unit/tax-data-validation.spec.js
@@ -192,6 +192,20 @@ test.describe("app-settings.json inputLimits", () => {
   });
 });
 
+test.describe("app-settings.json donationClaimLimitPercent", () => {
+  const appSettings = JSON.parse(readFileSync("config/app-settings.json", "utf-8"));
+
+  test("donationClaimLimitPercent exists", () => {
+    expect(appSettings.donationClaimLimitPercent).toBeDefined();
+  });
+
+  test("donationClaimLimitPercent is a number between 0 and 1 (exclusive)", () => {
+    expect(typeof appSettings.donationClaimLimitPercent).toBe("number");
+    expect(appSettings.donationClaimLimitPercent).toBeGreaterThan(0);
+    expect(appSettings.donationClaimLimitPercent).toBeLessThan(1);
+  });
+});
+
 test.describe("learn.json config", () => {
   const learnConfig = JSON.parse(readFileSync("config/learn.json", "utf-8"));
 

--- a/views/about/template.html
+++ b/views/about/template.html
@@ -12,7 +12,7 @@
     <li>We estimate your tax using <strong>only your income and the basic personal amount</strong> — no other credits or deductions</li>
     <li>We use the <strong>standard two-tier</strong> donation credit rates (first $200 / over $200) for all provinces — some provinces have additional tiers for very high earners that we don't model</li>
     <li>We assume <strong>cash donations only</strong> — we don't handle donations of securities or ecologically sensitive land</li>
-    <li>We don't enforce the <strong>75% of net income</strong> donation claiming limit (rarely relevant for typical donors)</li>
+    <li>We show an informational warning when your donation may exceed the CRA's <strong>75% of net income</strong> annual claiming limit, but we cannot calculate the exact limit since we only know your gross income</li>
     <li><strong>Quebec is not supported</strong> — Quebec has a separate tax system administered by Revenu Qu&eacute;bec</li>
   </ul>
 


### PR DESCRIPTION
## Summary

- Adds an informational amber callout in forward mode when the donation exceeds 75% of the user's entered income, explaining the CRA annual claiming limit (ITA s.118.1) and the 5-year carry-forward option
- Warning is honest about the net-vs-gross income gap — we explain the CRA uses net income (line 23600) without computing exact claimable amounts
- When both the 75% claim limit and unused credit warnings fire together, the narrative tells one coherent story instead of stacking independent warnings:
  - Non-refundable section reframed as "why spreading your claim also helps" with hypothetical framing and info (blue) callout instead of warning (red)
  - Carry-forward section shows spouse option only (carry-forward already covered by the claim limit section)
  - Minimum income section suppressed (misleading when the user can't claim the full donation in one year anyway)
- Reverse mode intentionally excluded (would clutter the compact UI)
- New `donationClaimLimitPercent` setting in `app-settings.json` (configurable, not hardcoded)

## Changes

| File | Change |
|------|--------|
| `config/app-settings.json` | Added `donationClaimLimitPercent: 0.75` |
| `js/check-donation-claim-limit.js` | New pure check function |
| `js/calculator.js` | Wire check into forward pipeline |
| `js/ui/narrative.js` | New `buildClaimLimitSection()` with amber callout; reframed non-refundable, carry-forward, and minimum income sections when 75% limit also fires |
| `views/about/template.html` | Updated About page bullet to reflect new warning |
| `docs/configuration.md` | Documented new setting |
| `scripts/capture-screenshots.js` | Added claim-limit screenshot scenarios (single + combined) |
| `tests/unit/check-donation-claim-limit.spec.js` | 7 unit tests for pure function |
| `tests/unit/tax-data-validation.spec.js` | Config validation for new setting |
| `tests/unit/smoke-current-year.spec.js` | claimLimit assertions in smoke tests |
| `tests/e2e/features/donation-claim-limit.feature` | 4 E2E scenarios (under/over/exactly 75%, combined with unused credit) |
| `tests/e2e/steps/donation-claim-limit.js` | Step definitions for claim limit |

## Combined narrative UX

When a large donation triggers both warnings (e.g. ON, $100K income, $95K donation), the sections now read as one story:

1. **CRA annual claiming limit** (amber) — you'll need to spread the claim across years
2. **Why spreading your claim also helps** (blue) — reframes the unused credit as hypothetical ("if you were to claim the full donation in a single year...") and ends with positive framing that spreading solves both problems
3. **Another option** (blue) — spouse option only (carry-forward already covered above)
4. ~~Minimum income~~ — suppressed (misleading when you can't claim the full donation in one year anyway)

See `scratch/34-75-percent-warning/high-donation-ux-analysis.md` for detailed rationale.

## Test plan

- [x] All 202 unit tests pass
- [x] All 61 E2E tests pass (1 skipped — known flaky back-button test)
- [x] Screenshots captured for desktop and mobile
- [ ] Manual verification with URLs in `scratch/34-75-percent-warning/verification.md`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)