### PR TITLE
[#39] Fix PARTLY_WASTED narrative for high-income donors

### DIFF
--- a/js/ui/narrative.js
+++ b/js/ui/narrative.js
@@ -174,7 +174,7 @@ async function buildTaxSituationSection(results) {
   if (usability.state === UsabilityState.PARTLY_WASTED) {
     return section("tax-situation",
       `<h3>Your tax situation</h3>
-<p>Based on your income of <span class="hl">${$(input.income)}</span> in ${input.provinceName}, we estimate your total income tax is approximately <span class="hl">${$(tax.totalTax)}</span>. Most of your income is sheltered by the basic personal amount, which means you owe very little tax.</p>`
+<p>Based on your income of <span class="hl">${$(input.income)}</span> in ${input.provinceName}, we estimate your total income tax is approximately <span class="hl">${$(tax.totalTax)}</span>. Your donation credit exceeds your tax payable, so part of the credit will go unused.</p>`
     );
   }
 

--- a/tests/e2e/features/donation-claim-limit.feature
+++ b/tests/e2e/features/donation-claim-limit.feature
@@ -26,6 +26,8 @@ Feature: CRA 75% donation claiming limit warning
     And the carry-forward section should not mention "Carry it forward"
     And the carry-forward section should mention "Let your spouse claim it"
     And I should not see the minimum income section
+    # Tax situation narrative must use neutral language, not low-income framing (#39)
+    And the tax situation should say the donation credit exceeds tax payable
 
   Scenario: Forward mode — donation exactly at 75% shows no warning
     When I select "Ontario" as my province

--- a/tests/e2e/features/donor-experience.feature
+++ b/tests/e2e/features/donor-experience.feature
@@ -126,7 +126,7 @@ Feature: Donor experience
     And the visual breakdown should show usable versus unused credit
     # Narrative
     And the explanation should show tiered rates for donations above $200
-    And the tax situation should say income is mostly sheltered by the basic personal amount
+    And the tax situation should say the donation credit exceeds tax payable
     And the results should include the non-refundable credit explanation
     And the results should include carry-forward and spouse options
     And the results should include the minimum income section
@@ -152,7 +152,7 @@ Feature: Donor experience
     And the visual breakdown should show usable versus unused credit
     # Narrative
     And the explanation should show a single rate for donations under $200
-    And the tax situation should say income is mostly sheltered by the basic personal amount
+    And the tax situation should say the donation credit exceeds tax payable
     And the results should include the non-refundable credit explanation
     And the results should include carry-forward and spouse options
     And the results should include the minimum income section
@@ -178,7 +178,7 @@ Feature: Donor experience
     And the visual breakdown should show usable versus unused credit
     # Narrative
     And the explanation should show a single rate for donations under $200
-    And the tax situation should say income is mostly sheltered by the basic personal amount
+    And the tax situation should say the donation credit exceeds tax payable
     And the results should include the non-refundable credit explanation
     And the results should include carry-forward and spouse options
     And the results should include the minimum income section

--- a/tests/e2e/steps/donor-experience.js
+++ b/tests/e2e/steps/donor-experience.js
@@ -152,11 +152,11 @@ Then(
 );
 
 Then(
-  "the tax situation should say income is mostly sheltered by the basic personal amount",
+  "the tax situation should say the donation credit exceeds tax payable",
   async ({ page }) => {
     const section = page.locator('[data-narrative="tax-situation"]');
     await expect(section).toBeVisible();
-    await expect(section).toContainText("sheltered by the basic personal amount");
+    await expect(section).toContainText("donation credit exceeds your tax payable");
   },
 );
 


### PR DESCRIPTION
## Summary
- Replace inaccurate "sheltered by the basic personal amount" / "very little tax" narrative with neutral text ("Your donation credit exceeds your tax payable, so part of the credit will go unused") that is correct for both low-income and high-income/huge-donation scenarios
- Update 3 existing E2E partly-wasted scenarios to assert new wording
- Add narrative assertion to existing claim-limit E2E scenario to guard against regression

Closes #39

## Test plan
- [x] All unit tests pass
- [x] All E2E tests pass (61 passed, 1 skipped @fixme)
- [ ] Manual verification: open localhost URLs from `scratch/partly-wasted-narrative-bug/verification.md`
- [ ] Run `LABEL=39-partly-wasted-narrative-fix npm run screenshots` and compare against previous set

🤖 Generated with [Claude Code](https://claude.com/claude-code)