### PR TITLE
[#42] Reword income input so it doesn't exclude retirees

### DIFF
--- a/css/income-explainer.css
+++ b/css/income-explainer.css
@@ -1,0 +1,113 @@
+@layer components {
+  /* Income explainer (<details>)
+     Collapsed: plain inline text link with chevron — deliberately NOT
+     boxed, so it never reads as another input field. Opens into a soft
+     teal panel that visually contains the explanation. */
+  .income-explainer {
+    margin-top: var(--space-sm);
+    margin-bottom: var(--space-sm);
+    border-radius: var(--radius-sm);
+    transition: background-color 0.15s ease;
+  }
+  .income-explainer[open] {
+    background: var(--color-primary-light);
+    border: 1px solid oklch(85% 0.04 192);
+  }
+
+  .income-explainer summary {
+    list-style: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-primary);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+  .income-explainer summary::-webkit-details-marker { display: none; }
+  .income-explainer summary::before {
+    content: "";
+    flex-shrink: 0;
+    width: 12px;
+    height: 12px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%230d7377' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><polyline points='4 6 8 10 12 6'/></svg>");
+    background-size: 12px 12px;
+    transform: rotate(-90deg);
+    transition: transform 0.15s ease;
+  }
+  .income-explainer[open] summary::before {
+    transform: rotate(0deg);
+  }
+  .income-explainer summary:hover { color: var(--color-primary-dark); }
+  .income-explainer summary:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* When the panel is open, the summary becomes the panel's heading row,
+     so style it as a flush block header instead of an inline link. */
+  .income-explainer[open] summary {
+    display: flex;
+    width: 100%;
+    padding: 10px 14px;
+    color: var(--color-primary-dark);
+    text-decoration: none;
+    border-bottom: 1px solid oklch(88% 0.03 192);
+  }
+  .income-explainer[open] summary::before {
+    width: 14px;
+    height: 14px;
+    background-size: 14px 14px;
+  }
+
+  .income-explainer-body {
+    padding: 12px 14px 14px;
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.65;
+  }
+  .income-explainer-body p { margin: 0; }
+  .income-explainer-body p + p { margin-top: 8px; }
+  .income-explainer-body ul {
+    margin: 8px 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 4px;
+  }
+  .income-explainer-body ul li {
+    position: relative;
+    padding-left: 14px;
+  }
+  .income-explainer-body ul li::before {
+    content: "";
+    position: absolute;
+    left: 4px;
+    top: 0.7em;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--color-primary);
+  }
+  .income-explainer-body ul li strong {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+  .income-explainer-body .learn-more {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 12px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-primary);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+  }
+  .income-explainer-body .learn-more:hover { gap: 8px; text-decoration: underline; }
+}

--- a/css/index.css
+++ b/css/index.css
@@ -5,6 +5,7 @@
 @import "layout.css";
 @import "buttons.css";
 @import "inputs.css";
+@import "income-explainer.css";
 @import "nav.css";
 @import "results.css";
 @import "narrative.css";

--- a/css/learn.css
+++ b/css/learn.css
@@ -32,6 +32,68 @@
     margin-bottom: var(--space-lg);
   }
 
+  .section-target {
+    /* Make anchored heading land below the sticky-ish header */
+    scroll-margin-top: 72px;
+  }
+
+  /* Income examples block (Learn page section) */
+  .income-source-list {
+    display: grid;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-lg);
+  }
+  .income-source {
+    display: grid;
+    grid-template-columns: 36px 1fr;
+    align-items: start;
+    gap: var(--space-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    padding: var(--space-md) var(--space-lg);
+  }
+  .income-source-tag {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--color-primary-light);
+    color: var(--color-primary-dark);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .income-source-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: 2px;
+  }
+  .income-source-detail {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.55;
+  }
+
+  .income-aside {
+    background: var(--color-bg-alt);
+    border-left: 3px solid var(--color-primary);
+    border-radius: var(--radius-sm);
+    padding: var(--space-md) var(--space-lg);
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.65;
+  }
+  .income-aside + .income-aside { margin-top: var(--space-sm); }
+  .income-aside strong { color: var(--color-text); }
+  .income-aside.aside-precise {
+    background: var(--color-primary-light);
+    border-left-color: var(--color-primary-dark);
+  }
+
   /* Scenario cards grid */
   .scenario-cards {
     display: grid;

--- a/js/router.js
+++ b/js/router.js
@@ -49,9 +49,10 @@ function buildFullPath(routePath) {
  * @param {string} routePath - e.g. "/" or "/about"
  * @param {object} options
  * @param {boolean} options.pushState - whether to push a history entry (false for popstate/initial load)
+ * @param {string} options.hash - optional fragment ("#foo") to preserve in URL and scroll to after render
  */
-async function navigate(routePath, { pushState = true, force = false } = {}) {
-  if (routePath === currentRoute && !force) return;
+async function navigate(routePath, { pushState = true, force = false, hash = "" } = {}) {
+  if (routePath === currentRoute && !force && !hash) return;
 
   const viewDir = routes[routePath];
   if (!viewDir) {
@@ -61,7 +62,7 @@ async function navigate(routePath, { pushState = true, force = false } = {}) {
 
   // Update URL and state synchronously (before async content loading)
   if (pushState) {
-    history.pushState({ route: routePath }, "", buildFullPath(routePath));
+    history.pushState({ route: routePath }, "", buildFullPath(routePath) + hash);
   }
 
   document.querySelectorAll("[data-route]").forEach((link) => {
@@ -70,6 +71,12 @@ async function navigate(routePath, { pushState = true, force = false } = {}) {
       link.getAttribute("data-route") === routePath,
     );
   });
+
+  // Same-route navigation with a fragment: just scroll, don't re-init the view.
+  if (routePath === currentRoute && !force) {
+    if (hash) scrollToHash(hash);
+    return;
+  }
 
   currentRoute = routePath;
 
@@ -93,7 +100,14 @@ async function navigate(routePath, { pushState = true, force = false } = {}) {
   // Signal that navigation is complete (used by e2e tests to detect route changes)
   contentEl.setAttribute("data-view", viewDir);
 
+  if (hash) scrollToHash(hash);
+
   trackPageView(currentRoute);
+}
+
+function scrollToHash(hash) {
+  const target = document.querySelector(hash);
+  if (target) target.scrollIntoView({ behavior: "instant", block: "start" });
 }
 
 /**
@@ -103,7 +117,7 @@ function start() {
   // Browser back/forward
   window.addEventListener("popstate", () => {
     const routePath = normalizePath(location.pathname);
-    navigate(routePath, { pushState: false });
+    navigate(routePath, { pushState: false, hash: location.hash });
   });
 
   // Intercept clicks on [data-route] links
@@ -113,12 +127,12 @@ function start() {
     event.preventDefault();
     const route = link.getAttribute("data-route");
     // Logo click forces fresh render even if already on the route
-    navigate(route, { force: link.classList.contains("logo") });
+    navigate(route, { force: link.classList.contains("logo"), hash: link.hash });
   });
 
   // Initial route
   const routePath = normalizePath(location.pathname);
-  navigate(routePath, { pushState: false });
+  navigate(routePath, { pushState: false, hash: location.hash });
 
   // Replace the initial history entry with a SPA-managed one.
   // Without this, the initial entry (from a real page load) can cause a full

--- a/tests/e2e/features/form-validation.feature
+++ b/tests/e2e/features/form-validation.feature
@@ -13,3 +13,12 @@ Feature: Form validation
     And I enter "80000" as my income
     And I enter "500" as my donation
     Then the Calculate button should be enabled
+
+  Scenario: Income explainer is visible and expands on click
+    Given I visit the calculator page
+    Then I should see the "What should I enter?" income explainer
+    And the income explainer should be collapsed
+    When I click the "What should I enter?" income explainer
+    Then the income explainer should be expanded
+    And the income explainer should mention working, retired, self-employed, and investments
+    And the income explainer should include a "Learn more" link

--- a/tests/e2e/features/learn-page.feature
+++ b/tests/e2e/features/learn-page.feature
@@ -19,7 +19,11 @@ Feature: Learn page
 
   Scenario: Learn page renders all content correctly
     Given I am on the Learn page
-    Then I should see the taxpayer categories section
+    Then I should see the "What income should I enter?" section
+    And the income section should list working, retired, self-employed, mixed, and investments
+    And the income section should mention the line 26000 taxable income reference
+    And the income section should appear before the taxpayer categories section
+    And I should see the taxpayer categories section
     And I should see 4 scenario cards
     And the non-taxpayer card should show $0 gets back
     And the partial taxpayer card should show a partial amount back

--- a/tests/e2e/features/navigation.feature
+++ b/tests/e2e/features/navigation.feature
@@ -109,6 +109,15 @@ Feature: Navigation
     And the URL should contain "province=ON"
     And the URL should contain "refund=100"
 
+  Scenario: Learn-more link from income explainer jumps to the matching Learn section
+    Given I visit the calculator page
+    When I expand the "What should I enter?" income explainer
+    And I click the "Learn more" link in the income explainer
+    Then I should see the Learn page content
+    And the URL should contain "/learn"
+    And the URL should contain "#what-income-to-enter"
+    And the "What income should I enter?" section should be in view
+
   # Flaky: history.back() timeout — see https://github.com/danielabar/charitable-tax-credit-calculator-canada/issues/11
   @fixme
   Scenario: Calculator state preserved after navigating away and back

--- a/tests/e2e/steps/form-validation.js
+++ b/tests/e2e/steps/form-validation.js
@@ -49,3 +49,57 @@ Then("the Calculate button should be enabled", async ({ page }) => {
   const button = page.locator(".btn-calculate");
   await expect(button).toBeEnabled();
 });
+
+const explainerSelector = "#forward-view details.income-explainer";
+
+Then(
+  'I should see the "What should I enter?" income explainer',
+  async ({ page }) => {
+    const summary = page.locator(`${explainerSelector} summary`);
+    await expect(summary).toBeVisible();
+    await expect(summary).toHaveText("What should I enter?");
+  }
+);
+
+Then("the income explainer should be collapsed", async ({ page }) => {
+  const isOpen = await page
+    .locator(explainerSelector)
+    .evaluate((el) => el.hasAttribute("open"));
+  expect(isOpen).toBe(false);
+});
+
+When(
+  'I click the "What should I enter?" income explainer',
+  async ({ page }) => {
+    await page.locator(`${explainerSelector} summary`).click();
+  }
+);
+
+Then("the income explainer should be expanded", async ({ page }) => {
+  const isOpen = await page
+    .locator(explainerSelector)
+    .evaluate((el) => el.hasAttribute("open"));
+  expect(isOpen).toBe(true);
+  await expect(page.locator(`${explainerSelector} .income-explainer-body`)).toBeVisible();
+});
+
+Then(
+  "the income explainer should mention working, retired, self-employed, and investments",
+  async ({ page }) => {
+    const body = page.locator(`${explainerSelector} .income-explainer-body`);
+    const text = (await body.textContent()).toLowerCase();
+    for (const keyword of ["working", "retired", "self-employed", "investments"]) {
+      expect(text).toContain(keyword);
+    }
+  }
+);
+
+Then(
+  'the income explainer should include a "Learn more" link',
+  async ({ page }) => {
+    const link = page.locator(`${explainerSelector} .income-explainer-body a.learn-more`);
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toContain("#what-income-to-enter");
+  }
+);

--- a/tests/e2e/steps/learn-page.js
+++ b/tests/e2e/steps/learn-page.js
@@ -104,3 +104,43 @@ Then("I should see the rate callout explaining the threshold", async ({ page }) 
   await expect(callout).toBeVisible();
   await expect(callout).toContainText("$200");
 });
+
+Then('I should see the "What income should I enter?" section', async ({ page }) => {
+  const section = page.locator("#what-income-to-enter");
+  await expect(section).toBeVisible();
+  await expect(section.locator("h2")).toHaveText("What income should I enter?");
+});
+
+Then(
+  "the income section should list working, retired, self-employed, mixed, and investments",
+  async ({ page }) => {
+    const section = page.locator("#what-income-to-enter");
+    const text = (await section.textContent()).toLowerCase();
+    for (const keyword of ["working", "retired", "self-employed", "mixed", "investments"]) {
+      expect(text).toContain(keyword);
+    }
+  }
+);
+
+Then(
+  "the income section should mention the line 26000 taxable income reference",
+  async ({ page }) => {
+    const section = page.locator("#what-income-to-enter");
+    await expect(section).toContainText("line 26000");
+    await expect(section).toContainText("taxable income");
+  }
+);
+
+Then(
+  "the income section should appear before the taxpayer categories section",
+  async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const incomeSection = document.querySelector("#what-income-to-enter");
+      const taxpayerSection = document.querySelector("#taxpayer-categories");
+      if (!incomeSection || !taxpayerSection) return null;
+      // DOCUMENT_POSITION_FOLLOWING (4) means taxpayer comes after income.
+      return incomeSection.compareDocumentPosition(taxpayerSection) & 4;
+    });
+    expect(result).toBeTruthy();
+  }
+);

--- a/tests/e2e/steps/navigation.js
+++ b/tests/e2e/steps/navigation.js
@@ -125,6 +125,36 @@ Then("I should see the forward calculator", async ({ page }) => {
  * to wait for the async popstate handler to finish rendering (it may call
  * runCalculation or updateSlider which fetch config files).
  */
+When(
+  'I expand the "What should I enter?" income explainer',
+  async ({ page }) => {
+    await page.locator("#forward-view details.income-explainer summary").click();
+  }
+);
+
+When(
+  'I click the "Learn more" link in the income explainer',
+  async ({ page }) => {
+    await page
+      .locator("#forward-view details.income-explainer .learn-more")
+      .click();
+    await page.waitForSelector(".learn-page");
+  }
+);
+
+Then(
+  'the "What income should I enter?" section should be in view',
+  async ({ page }) => {
+    const heading = page.locator("#what-income-to-enter h2");
+    await expect(heading).toBeVisible();
+    const inView = await heading.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      return rect.top >= 0 && rect.top < window.innerHeight;
+    });
+    expect(inView).toBe(true);
+  }
+);
+
 When("I press Back on the same page", async ({ page }) => {
   const currentUrl = page.url();
   await page.evaluate(() => {

--- a/views/calculator/template.html
+++ b/views/calculator/template.html
@@ -37,7 +37,20 @@
 
         <div class="form-group">
           <label for="income">Annual income</label>
-          <div class="hint">Your salary or wages before deductions</div>
+          <div class="hint">Your total income before tax (all sources)</div>
+          <details class="income-explainer">
+            <summary>What should I enter?</summary>
+            <div class="income-explainer-body">
+              <p>Enter your total yearly income before tax — from whatever sources you have. An approximate number is fine.</p>
+              <ul>
+                <li><strong>Working:</strong> your salary or wages (T4 box 14).</li>
+                <li><strong>Retired:</strong> CPP, OAS, employer pension, and any RRIF withdrawals — added together.</li>
+                <li><strong>Self-employed:</strong> your net business income for the year.</li>
+                <li><strong>Investments:</strong> interest, dividends, and capital gains.</li>
+              </ul>
+              <a class="learn-more" href="learn#what-income-to-enter" data-route="/learn">Learn more <span aria-hidden="true">&rarr;</span></a>
+            </div>
+          </details>
           <div class="input-prefix">
             <input type="text" id="income" name="income" inputmode="numeric" placeholder="0" required>
           </div>
@@ -86,7 +99,20 @@
       </div>
       <div class="form-group">
         <label for="rev-income">Annual income</label>
-        <div class="hint">Your salary or wages before deductions</div>
+        <div class="hint">Your total income before tax (all sources)</div>
+        <details class="income-explainer">
+          <summary>What should I enter?</summary>
+          <div class="income-explainer-body">
+            <p>Enter your total yearly income before tax — from whatever sources you have. An approximate number is fine.</p>
+            <ul>
+              <li><strong>Working:</strong> your salary or wages (T4 box 14).</li>
+              <li><strong>Retired:</strong> CPP, OAS, employer pension, and any RRIF withdrawals — added together.</li>
+              <li><strong>Self-employed:</strong> your net business income for the year.</li>
+              <li><strong>Investments:</strong> interest, dividends, and capital gains.</li>
+            </ul>
+            <a class="learn-more" href="learn#what-income-to-enter" data-route="/learn">Learn more <span aria-hidden="true">&rarr;</span></a>
+          </div>
+        </details>
         <div class="input-prefix">
           <input type="text" id="rev-income" inputmode="numeric" placeholder="0">
         </div>

--- a/views/learn/template.html
+++ b/views/learn/template.html
@@ -2,6 +2,65 @@
   <h1>How the charitable tax credit works</h1>
   <p class="page-intro">Not everyone benefits equally from a charitable donation. Your income — and how much tax you owe — determines whether you actually get money back.</p>
 
+  <section id="what-income-to-enter" class="learn-section section-target">
+    <h2>What income should I enter?</h2>
+    <p class="section-intro">The calculator asks for your annual income because that's what determines how much tax you'd owe — and therefore how much of the donation credit you can actually use.</p>
+
+    <div class="income-source-list">
+      <div class="income-source">
+        <div class="income-source-tag" aria-hidden="true">W</div>
+        <div>
+          <div class="income-source-title">If you're working</div>
+          <div class="income-source-detail">Use your salary or wages from your job — the gross amount, before tax. On a T4, that's box 14. If you have more than one job, add them up.</div>
+        </div>
+      </div>
+
+      <div class="income-source">
+        <div class="income-source-tag" aria-hidden="true">R</div>
+        <div>
+          <div class="income-source-title">If you're retired</div>
+          <div class="income-source-detail">Add up everything you receive in a year: CPP, OAS, your employer pension, and any RRIF withdrawals. Investment income too, if you have it. We're after the total before tax.</div>
+        </div>
+      </div>
+
+      <div class="income-source">
+        <div class="income-source-tag" aria-hidden="true">S</div>
+        <div>
+          <div class="income-source-title">If you're self-employed</div>
+          <div class="income-source-detail">Use your net business income for the year — what's left after subtracting your business expenses, but before personal income tax.</div>
+        </div>
+      </div>
+
+      <div class="income-source">
+        <div class="income-source-tag" aria-hidden="true">M</div>
+        <div>
+          <div class="income-source-title">If your income is mixed</div>
+          <div class="income-source-detail">Add together everything you'd report on a tax return — pension plus part-time wages, business income plus investments, and so on. One total.</div>
+        </div>
+      </div>
+
+      <div class="income-source">
+        <div class="income-source-tag" aria-hidden="true">I</div>
+        <div>
+          <div class="income-source-title">If you live on investments</div>
+          <div class="income-source-detail">Add up your interest, dividends, and any capital gains realized in the year. (Capital gains are partially taxable, but for this estimate the full amount is close enough.)</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="income-aside">
+      <p><strong>An approximate number is fine.</strong> This calculator is an estimate, not a tax filing — being within a few thousand dollars won't change your result meaningfully.</p>
+    </div>
+
+    <div class="income-aside">
+      <p><strong>Why this is conservative.</strong> The calculator estimates your tax using only the income you enter and the basic personal amount — it doesn't model deductions like RRSP contributions or other credits. So when it warns that part of your donation credit might go unused, the real situation could be a little better.</p>
+    </div>
+
+    <div class="income-aside aside-precise">
+      <p><strong>For the precise version.</strong> If you've filed before and want to be exact, the credit ultimately attaches to your <em>taxable income</em> — line 26000 on your last tax return. That's the most accurate number to enter, but the gross-income figures above will get you a useful answer.</p>
+    </div>
+  </section>
+
   <section id="taxpayer-categories" class="learn-section">
     <h2>What happens when you donate</h2>
     <p class="section-intro">The same donation produces very different results depending on your tax situation. Here are four common scenarios.</p>

--- a/views/learn/template.html
+++ b/views/learn/template.html
@@ -19,7 +19,7 @@
         <div class="income-source-tag" aria-hidden="true">R</div>
         <div>
           <div class="income-source-title">If you're retired</div>
-          <div class="income-source-detail">Add up everything you receive in a year: CPP, OAS, your employer pension, and any RRIF withdrawals. Investment income too, if you have it. We're after the total before tax.</div>
+          <div class="income-source-detail">Add up everything you receive in a year, before tax: CPP, OAS, your employer pension, and any RRIF withdrawals. Include investment income too, if you have it.</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replace the income hint *"Your salary or wages before deductions"* with *"Your total income before tax (all sources)"* on both forward and reverse modes, and add an inline `<details>` *"What should I enter?"* expander with examples by life situation.
- Add a new `/learn#what-income-to-enter` section with five life-situation cards (working, retired, self-employed, mixed, investments) and three asides on precision, why the estimate is conservative, and the line 26000 reference.
- Patch the SPA router to preserve URL fragments on `data-route` clicks and scroll to the target heading after render, so the explainer's *Learn more →* link lands on the new section.

Resolves #42

Resolves the SME-flagged exclusion problem: the prior wording read as if retirees, self-employed people, and investment-income donors weren't the target user. Closes Open Question #1 from the brainstorming requirements doc.

## Test plan
- [x] `npm run test:unit` — 202 unit tests pass
- [x] `npm run test:e2e` — 63 e2e tests pass (1 pre-existing `@fixme` skipped)
- [x] Three new/extended scenarios:
  - `learn-page.feature` — Learn page renders the new income section, lists all five life situations, mentions line 26000, and orders before taxpayer-categories.
  - `navigation.feature` — clicking *Learn more* from the calculator's explainer navigates to `/learn#what-income-to-enter` and scrolls the heading into view.
  - `form-validation.feature` — explainer is visible, collapsed by default, expands on click, exposes correct content and *Learn more* link.
- [x] `LABEL=income-wording-after npm run screenshots` — visual review of blank form, results states, reverse mode, and Learn page

🤖 Generated with [Claude Code](https://claude.com/claude-code)